### PR TITLE
Detect reasons of workflow job failures

### DIFF
--- a/.github/workflows/docs-prod.yml
+++ b/.github/workflows/docs-prod.yml
@@ -9,6 +9,8 @@ on:
       - 'docs/**'
       - 'README.md'
       - '.github/workflows/docs-prod.yml'
+      - 'multivac/gather_job_data.py'
+      - 'multivac/sensors/failures.py'
 jobs:
   deploy-doc-prod:
     runs-on: [ 'self-hosted', 'Linux', 'flavor-8-16' ]
@@ -35,6 +37,7 @@ jobs:
           ref: ${{github.head_ref}}
 
       - run: cp README.md docs/intro.md
+      - run: make autodoc
       - run: set -xe && cd docs && make -f ci.mk json
       - run: set -xe && cd docs && bash upload_output.sh
 

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -6,6 +6,8 @@ on:
       - 'docs/**'
       - 'README.md'
       - '.github/workflows/docs-test.yml'
+      - 'multivac/gather_job_data.py'
+      - 'multivac/sensors/failures.py'
 
 jobs:
   deploy-doc-branch:
@@ -33,6 +35,7 @@ jobs:
           ref: ${{github.head_ref}}
 
       - run: cp README.md docs/intro.md
+      - run: make autodoc
       - run: set -xe && cd docs && make -f ci.mk json
       - run: set -xe && cd docs && bash upload_output.sh
 

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ lint:
 .PHONY: test
 test:
 	python -m unittest test.sensors.test_status_test
+
+autodoc:
+	./multivac/docs.py

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 build
 intro.md
+gather_job_data/failures.rst

--- a/docs/gather_job_data.rst
+++ b/docs/gather_job_data.rst
@@ -1,5 +1,10 @@
-gather_job_data.py
-==================
+Gathering workflow data
+=======================
+
+..  toctree::
+    :hidden:
+
+    gather_job_data/failures
 
 Gathering data about workflow jobs.
 
@@ -40,3 +45,52 @@ To gather data from a number of most recent workflows, use `--latest`:
 ..  code-block:: console
 
     $ ./multivac/gather_job_data.py --latest 1000
+
+
+Detecting workflow failure reasons
+----------------------------------
+
+Multivac can detect types of workflow failures and calculate detailed statistics.
+Detailed description of known failure reasons can be found in
+:doc:`gather_job_data/failures`.
+
+..  code-block:: console
+
+    $ ./multivac/gather_job_data.py --latest 1000 --failure-stats
+
+    total 20
+    package_building_error 5
+    unknown 4
+    testrun_test_failed 3
+    telegram_bot_error 2
+    integration_vshard_test_failed 1
+    luajit_error 1
+    testrun_test_hung 1
+    git_repo_access_error 1
+    dependency_autoreconf 1
+    tap_test_failed 1
+
+
+Command `--watch-failure name` will return a list of jobs where the named failure has been detected,
+along with the links to workflow runs on GitHub and matching log lines:
+
+..  code-block:: console
+
+    $ ./multivac/gather_job_data.py --latest 1000 --watch-failure testrun_test_failed
+    7008229080  memtx_allocator_based_on_malloc      https://github.com/tarantool/tarantool/runs/7008229080?check_suite_focus=true
+                            2022-06-22T16:27:25.7389940Z * fail: 1
+    6936376158  osx_12       https://github.com/tarantool/tarantool/runs/6936376158?check_suite_focus=true
+                            2022-06-17T13:11:18.6461930Z * fail: 1
+    6933185565  fedora_34 (gc64)     https://github.com/tarantool/tarantool/runs/6933185565?check_suite_focus=true
+                            2022-06-17T09:24:50.6543965Z * fail: 1
+
+This is useful when working with yet undetected failure reasons:
+
+..  code-block:: console
+
+    $ ./multivac/gather_job_data.py --latest 1000 --watch-failure unknown
+
+    6966228368  freebsd-13   https://github.com/tarantool/tarantool/runs/6966228368?check_suite_focus=true
+                            None
+    6947333557  freebsd-12   https://github.com/tarantool/tarantool/runs/6947333557?check_suite_focus=true
+                            None

--- a/docs/gather_job_data/_includes/changelog_error.log
+++ b/docs/gather_job_data/_includes/changelog_error.log
@@ -1,0 +1,7 @@
+Run ./tools/gen-release-notes
+  ./tools/gen-release-notes
+  shell: /usr/bin/bash -e {0}
+  env:
+    CI_MAKE: make -f .travis.mk
+Unable to parse /home/ubuntu/actions-runner/_work/tarantool/tarantool/changelogs/unreleased/gh-6548-luajit-fixes.md: The first line should be a header, got 'Backported patches from vanilla LuaJIT trunk (gh-6548). In the scope of this'
+Error: Process completed with exit code 1.

--- a/docs/gather_job_data/_includes/checkpatch.log
+++ b/docs/gather_job_data/_includes/checkpatch.log
@@ -1,0 +1,7 @@
+ERROR:COMMIT_MESSAGE: Missing commit description - Add an appropriate one
+
+ERROR:NO_DOC: Please add doc or NO_DOC=<reason> tag
+ERROR:NO_CHANGELOG: Please add changelog or NO_CHANGELOG=<reason> tag
+ERROR:NO_TEST: Please add test or NO_TEST=<reason> tag
+total: 4 errors, 72 lines checked
+Commit 4a1714faf0c7 ("test flavor 8-16") has style problems, please review.

--- a/docs/gather_job_data/_includes/coveralls_io_unreachable.log
+++ b/docs/gather_job_data/_includes/coveralls_io_unreachable.log
@@ -1,0 +1,22 @@
+Run coverallsapp/github-action@v1.1.2
+  with:
+    github-token: ***
+    path-to-lcov: ./coverage.info
+    coveralls-endpoint: https://coveralls.io
+  env:
+    VARDIR: /tmp/t
+    TEST_RUN_RETRIES: 3
+    SERVER_START_TIMEOUT: 290
+    REPLICATION_SYNC_TIMEOUT: 300
+    TEST_TIMEOUT: 310
+    NO_OUTPUT_TIMEOUT: 320
+    PRESERVE_ENVVARS: VARDIR,TEST_RUN_RETRIES,SERVER_START_TIMEOUT,REPLICATION_SYNC_TIMEOUT,TEST_TIMEOUT,NO_OUTPUT_TIMEOUT,GC64
+    AWS_DEFAULT_REGION: MS
+Using lcov file: ./coverage.info
+Error: Bad response: 405 <html>
+<head><title>405 Not Allowed</title></head>
+<body>
+<center><h1>405 Not Allowed</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>

--- a/docs/gather_job_data/_includes/ctest_error.log
+++ b/docs/gather_job_data/_includes/ctest_error.log
@@ -1,0 +1,12 @@
+Errors while running CTest
+Output from these tests are in: /Users/tntmac04.tarantool.i/actions-runner/_work/tarantool/tarantool/static-build/Testing/Temporary/LastTest.log
+Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
+make: *** [build] Error 8
+4/4 Test #4: check-luarocks ...................   Passed    0.05 sec
+
+75% tests passed, 1 tests failed out of 4
+
+Total Test time (real) =   0.55 sec
+
+The following tests FAILED:
+	  1 - check-dependencies (Failed)

--- a/docs/gather_job_data/_includes/dependency_autoreconf.log
+++ b/docs/gather_job_data/_includes/dependency_autoreconf.log
@@ -1,0 +1,11 @@
+ make[4]: Entering directory '/opt/actions-runner/_work/tarantool/tarantool'
+[  3%] Creating directories for 'bundled-libcurl-project'
+[  3%] No download step for 'bundled-libcurl-project'
+[  3%] No patch step for 'bundled-libcurl-project'
+[  4%] No update step for 'bundled-libcurl-project'
+[  4%] Performing configure step for 'bundled-libcurl-project'
+*** Do not use buildconf. Instead, just use: autoreconf -fi
+./buildconf: 4: exec: autoreconf: not found
+make[4]: *** [CMakeFiles/bundled-libcurl-project.dir/build.make:107: build/curl/work/stamp/bundled-libcurl-project-configure] Error 127
+make[4]: Leaving directory '/opt/actions-runner/_work/tarantool/tarantool'
+make[3]: *** [CMakeFiles/Makefile2:1288: CMakeFiles/bundled-libcurl-project.dir/all] Error 2

--- a/docs/gather_job_data/_includes/docker_hub_unreachable.log
+++ b/docs/gather_job_data/_includes/docker_hub_unreachable.log
@@ -1,0 +1,4 @@
++ docker pull packpack/packpack:fedora-36
+Error response from daemon: Head "https://registry-1.docker.io/v2/packpack/packpack/manifests/fedora-36": Get "https://auth.docker.io/token?scope=repository%3Apackpack%2Fpackpack%3Apull&service=registry.docker.io": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
+make: *** [.pack.mk:29: package] Error 1
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/docker_rate_limit.log
+++ b/docs/gather_job_data/_includes/docker_rate_limit.log
@@ -1,0 +1,4 @@
+docker pull packpack/packpack:opensuse-leap-15.2
+Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
+make: *** [.gitlab.mk:112: package] Error 1
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/dpkg_buildpackage_error.log
+++ b/docs/gather_job_data/_includes/dpkg_buildpackage_error.log
@@ -1,0 +1,23 @@
+make[4]: Leaving directory '/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu/build/curl/work/curl'
+cd "/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu/build/curl/work/curl" && /usr/bin/cmake -E touch "/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu/build/curl/work/stamp/bundled-libcurl-project-install"
+[ 52%] Completed 'bundled-libcurl-project'
+/usr/bin/cmake -E make_directory "/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu/CMakeFiles"
+/usr/bin/cmake -E touch "/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu/CMakeFiles/bundled-libcurl-project-complete"
+/usr/bin/cmake -E touch "/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu/build/curl/work/stamp/bundled-libcurl-project-done"
+make[3]: Leaving directory '/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu'
+[ 52%] Built target bundled-libcurl-project
+make[2]: Leaving directory '/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu'
+Makefile:152: recipe for target 'all' failed
+make[1]: *** [all] Error 2
+make[1]: Leaving directory '/build/tarantool-2.11.0~entrypoint.201.dev/obj-x86_64-linux-gnu'
+/usr/share/cdbs/1/class/makefile.mk:47: recipe for target 'debian/stamp-makefile-build' failed
+make: *** [debian/stamp-makefile-build] Error 2
+dpkg-buildpackage: error: debian/rules build gave error exit status 2
+debuild: fatal error at line 1376:
+dpkg-buildpackage -rfakeroot -D -us -uc -Zxz -j4 failed
+/pack//deb.mk:124: recipe for target '/build/tarantool_2.11.0~entrypoint.201.dev-1_amd64.changes' failed
+make: *** [/build/tarantool_2.11.0~entrypoint.201.dev-1_amd64.changes] Error 29
+rm /build/ls-lR.txt /build/VERSION
+make: Leaving directory '/source'
+make: *** [.gitlab.mk:112: package] Error 2
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/failures.rst
+++ b/docs/gather_job_data/_includes/failures.rst
@@ -1,0 +1,2 @@
+Types of detected workflow failures
+===================================

--- a/docs/gather_job_data/_includes/git_repo_access_error_1.log
+++ b/docs/gather_job_data/_includes/git_repo_access_error_1.log
@@ -1,0 +1,8 @@
+git clone https://github.com/packpack/packpack.git
+Cloning into 'packpack'...
+error: RPC failed; curl 56 GnuTLS recv error (-9): Error decoding the received TLS packet.
+fatal: the remote end hung up unexpectedly
+fatal: early EOF
+fatal: index-pack failed
+make: *** [.pack.mk:26: prepare] Error 128
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/git_repo_access_error_2.log
+++ b/docs/gather_job_data/_includes/git_repo_access_error_2.log
@@ -1,0 +1,2 @@
+fatal: unable to access 'https://github.com/tarantool/tarantool/': GnuTLS recv error (-54): Error in the pull function.
+Error: Process completed with exit code 128.

--- a/docs/gather_job_data/_includes/git_unsafe_error.log
+++ b/docs/gather_job_data/_includes/git_unsafe_error.log
@@ -1,0 +1,19 @@
+Initializing the repository
+  /usr/bin/git init /home/ubuntu/actions-runner/_work/tarantool/tarantool
+  hint: Using 'master' as the name for the initial branch. This default branch name
+  hint: is subject to change. To configure the initial branch name to use in all
+  hint: of your new repositories, which will suppress this warning, call:
+  hint:
+  hint: 	git config --global init.defaultBranch <name>
+  hint:
+  hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+  hint: 'development'. The just-created branch can be renamed via this command:
+  hint:
+  hint: 	git branch -m <name>
+  Initialized empty Git repository in /home/ubuntu/actions-runner/_work/tarantool/tarantool/.git/
+  /usr/bin/git remote add origin https://github.com/tarantool/tarantool
+  Error: fatal: unsafe repository ('/home/ubuntu/actions-runner/_work/tarantool/tarantool' is owned by someone else)
+  To add an exception for this directory, call:
+
+  	git config --global --add safe.directory /home/ubuntu/actions-runner/_work/tarantool/tarantool
+  Error: The process '/usr/bin/git' failed with exit code 128

--- a/docs/gather_job_data/_includes/integration_tests_failed_1.log
+++ b/docs/gather_job_data/_includes/integration_tests_failed_1.log
@@ -1,0 +1,8 @@
+Ran 411 tests in 565.815 seconds, 408 succeeded, 2 xfailed, 1 failed, 3 skipped
+
+=========================================================
+Failed tests:
+
+integration.raft.test_promote_errors
+
+Error: Process completed with exit code 1.

--- a/docs/gather_job_data/_includes/integration_tests_failed_2.log
+++ b/docs/gather_job_data/_includes/integration_tests_failed_2.log
@@ -1,0 +1,11 @@
+Captured stderr:
+{"etcdserver":"2.3.8","etcdcluster":"2.3.0"}
+{"etcdserver":"2.3.8","etcdcluster":"2.3.0"}
+
+
+Ran 411 tests in 548.437 seconds, 408 succeeded, 2 xfailed, 1 failed, 2 skipped
+
+=========================================================
+Failed tests:
+
+integration.etcd2_client.test_longpolling

--- a/docs/gather_job_data/_includes/integration_vshard_test_failed.log
+++ b/docs/gather_job_data/_includes/integration_vshard_test_failed.log
@@ -1,0 +1,15 @@
+ ================================================================================
+TEST                                            PARAMS          RESULT
+---------------------------------------------------------------------------
+failover/cluster_changes.test.lua                               [ pass ]
+failover/failover.test.lua                                      [ fail ]
+
+...
+
+ ===== 1 tests failed:
+----- ('failover/failover.test.lua', None)
+make[3]: *** [test/CMakeFiles/test-force.dir/build.make:70: test/CMakeFiles/test-force] Error 255
+make[2]: *** [CMakeFiles/Makefile2:176: test/CMakeFiles/test-force.dir/all] Error 2
+make[1]: *** [CMakeFiles/Makefile2:183: test/CMakeFiles/test-force.dir/rule] Error 2
+make: *** [Makefile:182: test-force] Error 2
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/jepsen_error.log
+++ b/docs/gather_job_data/_includes/jepsen_error.log
@@ -1,0 +1,14 @@
+make[4]: *** [run-jepsen] Error 255
+CMakeFiles/run-jepsen.dir/build.make:61: recipe for target 'run-jepsen' failed
+make[3]: *** [CMakeFiles/run-jepsen.dir/all] Error 2
+make[4]: Leaving directory '/__w/tarantool/tarantool'
+make[2]: *** [CMakeFiles/run-jepsen.dir/rule] Error 2
+CMakeFiles/Makefile2:141: recipe for target 'CMakeFiles/run-jepsen.dir/all' failed
+make[3]: Leaving directory '/__w/tarantool/tarantool'
+CMakeFiles/Makefile2:148: recipe for target 'CMakeFiles/run-jepsen.dir/rule' failed
+make[2]: Leaving directory '/__w/tarantool/tarantool'
+make[1]: *** [run-jepsen] Error 2
+Makefile:210: recipe for target 'run-jepsen' failed
+make[1]: Leaving directory '/__w/tarantool/tarantool'
+make: *** [test_jepsen] Error 2
+.travis.mk:478: recipe for target 'test_jepsen' failed

--- a/docs/gather_job_data/_includes/jinja_build_error.log
+++ b/docs/gather_job_data/_includes/jinja_build_error.log
@@ -1,0 +1,5 @@
+cmake --build . --parallel $(nproc)
+ninja: error: build.ninja:2151: multiple rules generate third_party/luajit/src/luajit [-w dupbuild=err]
+
+make: *** [.travis.mk:180: build_coverage_debian] Error 1
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/linker_command_failed.log
+++ b/docs/gather_job_data/_includes/linker_command_failed.log
@@ -1,0 +1,17 @@
+[100%] Linking CXX executable watcher.test
+ld: error: undefined symbol: set_sigint_cb
+>>> referenced by console.c:261 (lua/console.c:261)
+>>>               console.c.o:(lbox_console_readline) in archive ../../src/box/libbox.a
+>>> referenced by console.c:342 (lua/console.c:342)
+>>>               console.c.o:(lbox_console_readline) in archive ../../src/box/libbox.a
+>>> referenced by console.c:352 (lua/console.c:352)
+>>>               console.c.o:(lbox_console_readline) in archive ../../src/box/libbox.a
+>>> referenced 1 more times
+c++: error: linker command failed with exit code 1 (use -v to see invocation)
+gmake[3]: *** [test/unit/CMakeFiles/watcher.test.dir/build.make:152: test/unit/watcher.test] Error 1
+gmake[3]: Leaving directory '/home/freebsd/.cache/act/2e58a162-8d47-4f5d-af53-51eff0852429/hostexecutor'
+gmake[2]: *** [CMakeFiles/Makefile2:10295: test/unit/CMakeFiles/watcher.test.dir/all] Error 2
+gmake[2]: Leaving directory '/home/freebsd/.cache/act/2e58a162-8d47-4f5d-af53-51eff0852429/hostexecutor'
+gmake[1]: *** [Makefile:156: all] Error 2
+gmake[1]: Leaving directory '/home/freebsd/.cache/act/2e58a162-8d47-4f5d-af53-51eff0852429/hostexecutor'
+*** Error code 2

--- a/docs/gather_job_data/_includes/luajit_error_1.log
+++ b/docs/gather_job_data/_includes/luajit_error_1.log
@@ -1,0 +1,3 @@
+2022-04-21T17:48:22.1684535Z Running LuaJIT-tests
+2022-04-21T17:48:22.1885692Z PANIC: unprotected error in call to Lua API (builtin/utils.symtab.lua:9: module 'utils.avl' not found:
+2022-04-21T17:48:22.1886360Z 	no field package.preload['utils.avl']

--- a/docs/gather_job_data/_includes/luajit_error_2.log
+++ b/docs/gather_job_data/_includes/luajit_error_2.log
@@ -1,0 +1,12 @@
+Running Tarantool tests
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/gh-4773-tonumber-fail-on-NUL-char.test.lua ........... ok
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/gh-6065-jit-library-smoke-tests.test.lua ............. ok
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/lj-505-fold-no-strref-for-ptrdiff.test.lua ........... ok
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/gh-6189-cur_L.test.lua ............................... ok
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/gh-4427-ffi-sandwich.test.lua ........................ ok
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/misclib-getmetrics-capi.test.lua ..................... ok
+LuajitError: not enough memory
+fatal error, exiting the event loop
+/home/ubuntu/actions-runner/_work/tarantool/tarantool/third_party/luajit/test/tarantool-tests/misclib-sysprof-lapi.test.lua ........................
+Dubious, test returned 1 (wstat 256, 0x100)
+All 14 subtests passed

--- a/docs/gather_job_data/_includes/package_building_error_1.log
+++ b/docs/gather_job_data/_includes/package_building_error_1.log
@@ -1,0 +1,22 @@
+Install the project...
+-- Install configuration: "RelWithDebInfo"
+-- Installing: /Users/tntmac07.tarantool.i/actions-runner/_work/tarantool/tarantool/build/curl/dest/lib/libcurl.a
+...
+-- Installing: /Users/tntmac07.tarantool.i/actions-runner/_work/tarantool/tarantool/build/curl/dest/lib/cmake/CURL/CURLConfig.cmake
+[ 63%] Completed 'bundled-libcurl-project'
+[ 63%] Built target bundled-libcurl-project
+[ 63%] Built target build_bundled_libs
+make[3]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
+make[3]: *** Waiting for unfinished jobs....
+[ 63%] Generating ../third_party/luajit/tools/utils/symtab.lua.c
+[ 63%] Generating lua/clock.lua.c
+[ 63%] Generating lua/buffer.lua.c
+[ 63%] Generating lua/csv.lua.c
+[ 63%] Generating lua/argparse.lua.c
+[ 65%] Generating lua/debug.lua.c
+[ 65%] Generating lua/datetime.lua.c
+[ 65%] Generating lua/crypto.lua.c
+make[2]: *** [src/CMakeFiles/server.dir/all] Error 2
+make[1]: *** [all] Error 2
+make: *** [build_osx] Error 2
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/package_building_error_2.log
+++ b/docs/gather_job_data/_includes/package_building_error_2.log
@@ -1,0 +1,6 @@
+/build/usr/src/debug/tarantool-2.11.0~entrypoint.201.dev/src/lib/core/datetime.c: At top level:
+cc1: error: unrecognized command line option '-Wno-cast-function-type' [-Werror]
+cc1: error: unrecognized command line option '-Wno-gnu-alignof-expression' [-Werror]
+cc1: all warnings being treated as errors
+make[3]: *** [src/lib/core/CMakeFiles/core.dir/build.make:834: src/lib/core/CMakeFiles/core.dir/datetime.c.o] Error 1
+make[3]: *** Waiting for unfinished jobs....

--- a/docs/gather_job_data/_includes/repo_certificate_expired.log
+++ b/docs/gather_job_data/_includes/repo_certificate_expired.log
@@ -1,0 +1,22 @@
+sudo apt-get update  && \
+	sudo apt-get install -y -f libreadline-dev libunwind-dev
+Hit:1 http://ms1.clouds.archive.ubuntu.com/ubuntu focal InRelease
+Get:2 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
+Hit:3 https://download.docker.com/linux/ubuntu focal InRelease
+Get:4 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
+Ign:5 https://repo.zabbix.com/zabbix-agent2-plugins/1/ubuntu focal InRelease
+Get:6 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [1935 kB]
+Get:7 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [15.6 kB]
+Get:8 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1119 kB]
+Get:9 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [592 B]
+Get:10 http://ms1.clouds.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [924 kB]
+Ign:11 https://repo.zabbix.com/zabbix/6.0/ubuntu focal InRelease
+Err:12 https://repo.zabbix.com/zabbix-agent2-plugins/1/ubuntu focal Release
+  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 178.128.6.101 443]
+Err:13 https://repo.zabbix.com/zabbix/6.0/ubuntu focal Release
+  Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 178.128.6.101 443]
+Reading package lists...
+E: The repository 'https://repo.zabbix.com/zabbix-agent2-plugins/1/ubuntu focal Release' does not have a Release file.
+E: The repository 'https://repo.zabbix.com/zabbix/6.0/ubuntu focal Release' does not have a Release file.
+make: *** [.travis.mk:89: deps_ubuntu_ghactions] Error 100
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/tap_test_failed.log
+++ b/docs/gather_job_data/_includes/tap_test_failed.log
@@ -1,0 +1,26 @@
+not ok - failed subtests
+  ---
+  filename: ./test.lua
+  trace:
+  - line: 245
+    source: '@builtin/tap.lua'
+    filename: builtin/tap.lua
+    what: Lua
+    namewhat: method
+    name: test
+    src: builtin/tap.lua
+  - line: 0
+    source: '@./test.lua'
+    filename: ./test.lua
+    what: main
+    namewhat:
+    src: ./test.lua
+  planned: 4
+  failed: 1
+  line: 0
+  ...
+    # execution error test
+    1..2
+    ok - checking restart count
+    ok - Error task executed
+    # execution error test: end

--- a/docs/gather_job_data/_includes/telegram_bot_error.log
+++ b/docs/gather_job_data/_includes/telegram_bot_error.log
@@ -1,0 +1,6 @@
+ Sending commit message part as a single line: build: fix check-dependencies test on OS XTELEGRAMNEWLINETELEGRAMNEWLINECommit ed16c1e5780cf355ab9bf923ee6f9daf5b6363f8 (build: fix ...
+  File "<string>", line 1
+    import markdown ;   from bs4 import BeautifulSoup ;   md = markdown.markdown("build: fix check-dependencies test on OS XTELEGRAMNEWLINETELEGRAMNEWLINECommit ed16c1e5780cf355ab9bf923ee6f9daf5b6363f8 (build:
+                                                                                                                                                                                                                 ^
+SyntaxError: EOL while scanning string literal
+Error: Process completed with exit code 1.

--- a/docs/gather_job_data/_includes/testrun_internal.log
+++ b/docs/gather_job_data/_includes/testrun_internal.log
@@ -1,0 +1,22 @@
+Statistics:
+* pass: 1365
+* disabled: 159
+* skip: 4
+[Internal test-run error] The following tasks were dispatched to some worker task queue, but were not reported as done (does not matters success or fail):
+- [replication/replica_rejoin.test.lua, memtx]
+- [replication/gh-5426-election-on-off.test.lua, null]
+- [replication/gh-3711-misc-no-restart-on-same-configuration.test.lua, null]
+- [replication/skip_conflict_row.test.lua, memtx]
+- [replication/election_qsync.test.lua, vinyl]
+- [replication/box_set_replication_stress.test.lua, vinyl]
+- [replication/gc.test.lua, vinyl]
+- [replication/gh-5287-boot-anon.test.lua, memtx]
+- [replication/qsync_advanced.test.lua, vinyl]
+- [replication/qsync_basic.test.lua, vinyl]
+- [replication/gh-5445-leader-inconsistency.test.lua, null]
+- [replication/sync.test.lua, vinyl]
+- [replication/replica_rejoin.test.lua, vinyl]
+- [replication/replicaset_ro_mostly.test.lua, vinyl]
+- [replication/gc.test.lua, memtx]
+make: *** [run-test] Error 4
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/testrun_test_failed.log
+++ b/docs/gather_job_data/_includes/testrun_test_failed.log
@@ -1,0 +1,11 @@
+---------------------------------------------------------------------------------
+Statistics:
+* disabled: 162
+* pass: 1369
+* fail: 2
+Failed tasks:
+- [vinyl-luatest/gh_6568_replica_initial_join_removal_of_compacted_run_files_test.lua,
+  null]
+# logfile:        /tmp/t/log/001_vinyl-luatest.log
+# reproduce file: /tmp/t/reproduce/001_vinyl-luatest.list.yaml
+---

--- a/docs/gather_job_data/_includes/testrun_test_hung.log
+++ b/docs/gather_job_data/_includes/testrun_test_hung.log
@@ -1,0 +1,27 @@
+[052] vinyl/errinj_gc.test.lua                                        [ pass ]
+No output during 60 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
+- 019_replication-luatest [replication-luatest/gh_6842_qsync_applier_order_test.lua, None] at /tmp/t/019_replication-luatest/gh_6842_qsync_applier_order.result:0
+No output during 120 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
+- 019_replication-luatest [replication-luatest/gh_6842_qsync_applier_order_test.lua, None] at /tmp/t/019_replication-luatest/gh_6842_qsync_applier_order.result:0
+No output during 180 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
+- 019_replication-luatest [replication-luatest/gh_6842_qsync_applier_order_test.lua, None] at /tmp/t/019_replication-luatest/gh_6842_qsync_applier_order.result:0
+No output during 240 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
+- 019_replication-luatest [replication-luatest/gh_6842_qsync_applier_order_test.lua, None] at /tmp/t/019_replication-luatest/gh_6842_qsync_applier_order.result:0
+No output during 300 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
+- 019_replication-luatest [replication-luatest/gh_6842_qsync_applier_order_test.lua, None] at /tmp/t/019_replication-luatest/gh_6842_qsync_applier_order.result:0
+No output during 360 seconds. Will abort after 320 seconds without output. List of workers not reporting the status:
+- 019_replication-luatest [replication-luatest/gh_6842_qsync_applier_order_test.lua, None] at /tmp/t/019_replication-luatest/gh_6842_qsync_applier_order.result:0
+Test hung! Result content mismatch:
+[File does not exist: replication-luatest/gh_6842_qsync_applier_order.result]
+
+[Main process] No output from workers. It seems that we hang. Send SIGKILL to workers; exiting...
+
+...
+
+---------------------------------------------------------------------------------
+Statistics:
+* pass: 1438
+* disabled: 53
+* undone: 38
+make: *** [.travis.mk:185: test_coverage_debian_no_deps] Error 1
+Error: Process completed with exit code 2.

--- a/docs/gather_job_data/_includes/workflows.csv
+++ b/docs/gather_job_data/_includes/workflows.csv
@@ -1,3 +1,4 @@
-job_id,job_name,status,queued_at,started_at,completed_at,platform,runner_label,runner_name,runner_version
-7009010343,osx_11_aarch64,success,2022-06-22T17:02:50Z,2022-06-22T17:02:57Z,2022-06-22T17:05:49Z,aarch64,['macos-11-m1'],tntmac07,2.293.0
-7008230674,ubuntu_18_04 (gc64),failure,2022-06-22T16:13:47Z,2022-06-22T16:14:15Z,2022-06-22T16:20:15Z,amd64,['ubuntu-20.04-self-hosted'],ghacts-ce-extra-10,2.293.0
+job_id,job_name,status,failure_type,queued_at,started_at,completed_at,platform,runner_label,runner_name,runner_version
+7009010343,osx_11_aarch64,success,,2022-06-22T17:02:50Z,2022-06-22T17:02:57Z,2022-06-22T17:05:49Z,aarch64,['macos-11-m1'],tntmac07,2.293.0
+7008230674,ubuntu_18_04 (gc64),failure,git_repo_access_error,2022-06-22T16:13:47Z,2022-06-22T16:14:15Z,2022-06-22T16:20:15Z,amd64,['ubuntu-20.04-self-hosted'],ghacts-ce-extra-10,2.293.0
+

--- a/docs/gather_job_data/_includes/workflows.json
+++ b/docs/gather_job_data/_includes/workflows.json
@@ -1,5 +1,6 @@
 {
   "7009010343": {
+    "job_id": 7009010343,
     "job_name": "osx_11_aarch64",
     "status": "success",
     "queued_at": "2022-06-22T17:02:50Z",
@@ -13,6 +14,7 @@
     "runner_version": "2.293.0"
   },
   "7008230674": {
+    "job_id": 7008230674,
     "job_name": "ubuntu_18_04 (gc64)",
     "status": "failure",
     "queued_at": "2022-06-22T16:13:47Z",
@@ -23,6 +25,7 @@
     ],
     "platform": "amd64",
     "runner_name": "ghacts-ce-extra-10",
-    "runner_version": "2.293.0"
+    "runner_version": "2.293.0",
+    "failure_type": "git_repo_access_error"
   }
 }

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ..  toctree::
-    :maxdepth: 1
+    :maxdepth: 7
 
     intro
     gather_job_data

--- a/multivac/docs.py
+++ b/multivac/docs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import glob
+import os
+
+from sensors.failures import failure_specs
+
+log_examples_path = 'docs/gather_job_data/'
+
+
+def describe_failure_type(failure_spec: dict, heading_marker='-'):
+    type_ = failure_spec['type']
+    # anchor and heading
+    yield f'\n..  _{type_}:\n\n{type_}\n{heading_marker * len(type_)}\n\n'
+
+    if 'description' in failure_spec:
+        yield f"{failure_spec['description']}\n\n"
+
+    yield "Regular expressions:\n\n..  code-block:: python\n\n"
+    for regexp in failure_spec['re']:
+        yield f"    r'{regexp}'\n"
+
+    files = glob.glob(
+        os.path.join(
+            log_examples_path,
+            '_includes/'
+            f'{type_}*.log')
+    )
+
+    if len(files) > 0:
+        for file in files:
+            included_file = os.path.split(file)
+            yield '\nLog example:\n\n'
+            yield f'..  literalinclude:: _includes/{included_file[1]}\n' \
+                  f'    :language: console\n\n'
+
+
+if __name__ == '__main__':
+
+    failures_rst_path = 'docs/gather_job_data/failures.rst'
+    with open(failures_rst_path, 'w') as failures_rst:
+        print(f'Autogenerating {failures_rst_path}')
+        failures_rst.writelines(
+            '..  include:: _includes/failures.rst\n\n'
+        )
+
+        failure_specs_sorted = list(sorted(
+            failure_specs, key=lambda x: x['type']
+        ))
+        for failure_spec in failure_specs_sorted:
+            failures_rst.writelines(describe_failure_type(failure_spec))

--- a/multivac/sensors/failures.py
+++ b/multivac/sensors/failures.py
@@ -1,0 +1,240 @@
+failure_categories = [
+    {
+        'tag': 'git',
+        'title': 'Git problems',
+        'description': 'Git-related problem: inaccessible remotes, '
+                       'broken repository, '
+                       'revision not found and other such stuff.',
+    },
+    {
+        'tag': 'network',
+        'description': 'Network problems: distribution repository '
+                       'inaccessible, bad SSL certificates, etc.',
+    },
+    {
+        'tag': 'tests',
+        'description': 'Tests failed',
+    },
+    {
+        'tag': 'tarantool',
+        'description': 'Internal Tarantool problem',
+    }
+]
+failure_specs = [
+    {
+        'type': 'git_unsafe_error',
+        're': [r'.*fatal: unsafe repository.*'],
+        'description': '',
+    },
+    {
+        'type': 'testrun_test_failed',
+        're': [
+            r'.*\* fail: \d+.*',
+        ],
+        'description': 'Typical test failure.',
+    },
+    {
+        'type': 'integration_vshard_test_failed',
+        're': [
+            r'.*===== \d+ tests failed:.*',
+        ],
+        'description': 'Typical test failure.',
+    },
+    {
+        'type': 'package_building_error',
+        're': [
+            r'.*make\[3\]: \*\*\* .*c.o] Error 1.*',
+            r'.*make\[\d\]: \*\*\* read jobs pipe: Resource temporarily unavailable.*',
+        ],
+        'description': '',
+    },
+    {
+        'type': 'luajit_error',
+        're': [
+            r'.*fatal error, exiting the event loop.*',
+            r'.*PANIC: unprotected error.*',
+        ],
+        'description': '',
+    },
+    {
+        'type': 'database_error',
+        're': [r'.*tarantool.error.DatabaseError.*'],
+        'description': '',
+    },
+    {
+        'type': 'yum_repo_error',
+        're': [r'.*- Status code: (404|503) for.*'],
+        'description': '',
+    },
+    {
+        'type': 'testrun_internal',
+        're': [r'.*\[Internal test-run error].*'],
+        'description': '',
+    },
+    {
+        'type': 'luatest_failed',
+        're': [
+            r'.*Test failed!.*',
+            r'.*Tests with errors:.*',
+        ],
+        'description': '',
+    },
+    {
+        'type': 'testrun_test_hung',
+        're': [r'.*Test hung!.*'],
+        'description': 'Test had started but did not return results.',
+    },
+
+    {
+        'type': 'curl_error',
+        're': [r'.*curl: \(22\) The requested URL returned error:.*'],
+        'description': 'Generic error when trying to fetch network resource with curl.',
+    },
+    {
+        'type': 'integration_tests_failed',
+        're': [
+            r'.*Captured stderr:.*',
+            r'.*mFailed tests:.*',
+        ],
+        'description': 'Tests failed in an integration workflow between tarantool '
+                       'and one of its modules',
+    },
+    {
+        'type': 'python_not_found',
+        're': [r'.*python3.\d+: not found.*'],
+        'description': '',
+    },
+    {
+        'type': 'vshard_error',
+        're': [r'.*E> Error.*'],
+        'description': '',
+    },
+    {
+        'type': 'jepsen_error',
+        're': [r'.*make\[\d+]: \*\*\* \[.*run-jepsen] Error.*'],
+        'description': '',
+    },
+    {
+        'type': 'dir_not_empty',
+        're': [r'.*rm: cannot remove \'.*\': Directory not empty.*'],
+        'description': '',
+    },
+    {
+        'type': 'git_repo_access_error',
+        're': [r'.*fatal: unable to access \'https://github.com.*',
+               r'.* fatal: the remote end hung up unexpectedly.*',
+               ],
+        'description': '',
+    },
+    {
+        'type': 'dpkg_buildpackage_error',
+        're': [r'.*dpkg-buildpackage: error: debian/rules build.*'],
+        'description': '',
+    },
+
+    {
+        'type': 'git_submodule_error',
+        're': [r'.*fatal: Needed a single revision.*'],
+        'description': '',
+    },
+    {
+        'type': 'go_tarantool_error',
+        're': [r'.*FAIL\s+github.com/tarantool/go-tarantool.*'],
+        'description': '',
+    },
+    {
+        'type': 'ctest_error',
+        're': [r'.*The following tests FAILED:.*'],
+        'description': '',
+    },
+    {
+        'type': 'lto_error',
+        're': [r'.*lto-wrapper: fatal error:.*'],
+        'description': '',
+    },
+    {
+        'type': 'checkpatch',
+        're': [r'.*total: [1-9][\d+]* errors, \d+ lines checked.*'],
+        'description': 'Checkpatch is a linter that checks commits have proper descriptions, '
+                       'and code changes have changelogs and documentation drafts.',
+    },
+    {
+        'type': 'telegram_bot_error',
+        're': [r'.*SyntaxError: EOL while scanning string literal.*'],
+        'description': 'Telegram bot failed to process commit message.',
+    },
+    {
+        'type': 'dependency_autoreconf',
+        're': [r'.*exec: autoreconf: not found.*'],
+        'description': 'Dependency error: autoreconf not found.',
+    },
+    {
+        'type': 'ssl_certificate_problem',
+        # this was named 'hashicorp_error' before,
+        # but it can happen with other sources just as well
+        're': [r'.*curl: \(60\) SSL certificate problem:.*'],
+        'description': '',
+    },
+    {
+        'type': 'tap_test_failed',
+        're': [r'.*failed subtest: \d+.*'],
+        'description': 'Failure of a TAP test.',
+    },
+    {
+        'type': 'could_not_find_readline',
+        're': [r'.*Could NOT find Readline.*'],
+        'description': '',
+    },
+    {
+        'type': 'linker_error',
+        're': [r'.*clang-14: error: linker.*'],
+        'description': '',
+    },
+    {
+        'type': 'docker_rate_limit',
+        're': [r'.*Error response from daemon: toomanyrequests.*'],
+        'description': '',
+    },
+
+    {
+        'type': 'linker_command_failed',
+        're': [r'.*error: linker command failed.*'],
+        'description': '',
+    },
+    {
+        'type': 'docker_hub_unreachable',
+        're': [
+            r'.*Error response from daemon: Head .* EOF.*',
+            r'.*Error response from daemon: Head .* request canceled.*',
+            r'.*error parsing HTTP 408 response body: invalid character.*'
+        ],
+        'description': '',
+    },
+    {
+        'type': 'repo_certificate_expired',
+        're': [r'.*Certificate verification failed: The certificate is NOT trusted.*'],
+        'description': '',
+    },
+    {
+        'type': 'ninja_build_error',
+        're': [r'.*ninja: error: build.ninja:\d*: multiple rules generate.*']
+    },
+    {
+        'type': 'coveralls_io_unreachable',
+        're': [r'.*##\[error\]Bad response: 4\d\d.*'],
+        'description': 'Failed to connect to coveralls.io.',
+    },
+    {
+        'type': 'changelog_error',
+        're': [r'.*Unable to parse.*changelogs.*'],
+        'description': 'Error in changelog syntax'
+    },
+    {
+        'type': 'yum_repo_certificate_error',
+        're': [
+            # r'.*Err:\d+ https*://.* InRelease.*',
+            r'.*Cannot retrieve metalink for repository: .*',
+        ],
+        'description': 'https://stackoverflow.com/questions/26734777/',
+    },
+]


### PR DESCRIPTION
Detect reasons of workflow job failures
    
* Add regular expressions for about 30 most popular reasons.
* Calculate and print overall stats with `--failure-stats`.
* Log all found failures of a certain type with `--watch-failure`.
* Add documentation on new commmands and detectable failure reasons. Part of documentation is generated from code with `./multivac/docs.py`.
    
Resolves #22
