### PR TITLE
last_seen: provide links to stored json and log data

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
+max-line-length = 100
+exclude = venv,.venv
 per-file-ignores =
     test/sensors/test_status_test.py: E501

--- a/.github/workflows/test-last-seen.yml
+++ b/.github/workflows/test-last-seen.yml
@@ -1,27 +1,20 @@
-name: Update test stats
+name: Check updating test stats
 
 on:
-  schedule:
-    - cron: 42 6-22/2 * * *
+  pull_request:
+    paths:
+      - 'multivac/last_seen.py'
+      - 'multivac/sensors'
+      - '.github/workflows/test-last-seen.yml'
 
 jobs:
   deploy:
     runs-on: ['self-hosted', 'multivac-crawler']
+    env:
+      LOG_STORAGE_BUCKET_URL: ${{ secrets.LOG_STORAGE_BUCKET_URL }}
     steps:
       - name: update repo
-        run: git checkout master && git fetch && git reset --hard origin/master
-        working-directory: /mnt/storage/multivac
-
-      - name: fetch.py for master
-        run: ./multivac/fetch.py --branch master tarantool/tarantool
-        working-directory: /mnt/storage/multivac
-
-      - name: fetch.py for 2.10
-        run: ./multivac/fetch.py --branch 2.10 tarantool/tarantool
-        working-directory: /mnt/storage/multivac
-
-      - name: fetch.py for 1.10
-        run: ./multivac/fetch.py --branch 1.10 tarantool/tarantool
+        run: git fetch && git checkout ${{ github.head_ref }}
         working-directory: /mnt/storage/multivac
 
       - name: make csv


### PR DESCRIPTION
Resulting CSV looks like this:

```csv
timestamp,test,conf,branch,status,count,runs_on,url,job_json,job_log,run_json
2022-06-22 16:23:18+00:00,app-luatest/gh_5747_crash_multiple_args_test.l>,,master,transient fail,38,graviton,https://github.com/tarantool/tarantool/runs/7008228471?check_suite_focus=true,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_run_jobs/7008228471.json,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_run_jobs/7008228471.log,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_runs/2543635332.json
2022-06-22 16:14:02+00:00,replication/box_set_replication_stress.test.lua,vinyl,master,fail,20,macos-10.15,https://github.com/tarantool/tarantool/runs/7008230119?check_suite_focus=true,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_run_jobs/7008230119.json,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_run_jobs/7008230119.log,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_runs/2543635352.json
2022-06-22 16:14:00+00:00,replication/box_set_replication_stress.test.lua,vinyl,master,fail,7,macos-11,https://github.com/tarantool/tarantool/runs/7008229745?check_suite_focus=true,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_run_jobs/7008229745.json,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_run_jobs/7008229745.log,https://multivac.hb.bizmrg.com/tarantool/tarantool/workflow_runs/2543635329.json
```

Resolve #3