### PR TITLE
influxdb: add the connector

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,4 @@
+INFLUX_JOB_BUCKET=test
+INFLUX_TOKEN=
+INFLUX_ORG=test
+INFLUX_URL=http://localhost:8086

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Secret token for GitHub
 token.txt
 
-# Secret environmental variables
+# Secret environment variables
 .env
 
 # Fetched metainfo, logs, cached data views.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Secret token for GitHub
 token.txt
 
+# Secret environmental variables
+.env
+
 # Fetched metainfo, logs, cached data views.
 workflow_runs
 workflow_run_jobs

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Add a token on [Personal access token][gh_token] GitHub page, give
 `repo:public_repo` access and copy the token to `token.txt`. All the scripts
 should be started from the root of the project.
 
+You can set all necessary environment variables at `.env` file as in
+`.env-example` and then run the command:
+
+```bash
+source .env && export $(cut -d= -f1 .env)
+```
+
 ### Collect logs:
 
 ```

--- a/docs/gather_job_data.rst
+++ b/docs/gather_job_data.rst
@@ -34,6 +34,11 @@ Same with JSON:
 ..  literalinclude:: ./gather_job_data/_includes/workflows.json
     :language: json
 
+Or you can store data in InfluxDB (see :doc:`influxdb`):
+
+..  code-block:: console
+
+    $ multivac/gather_job_data.py --format influxdb
 
 Limiting and filtering workflows
 --------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,4 +7,5 @@ Multivac
 
     intro
     gather_job_data
+    influxdb
 

--- a/docs/influxdb.rst
+++ b/docs/influxdb.rst
@@ -1,27 +1,76 @@
-How to connect to InfluxDB
-==========================
+InfluxDB connector
+==================
 
-1. Install InfluxDB 2 according to
-[official instruction](https://docs.influxdata.com/influxdb/v2.4/install/)
-2. Launch InfluxDB:
-```bash
-influxd
-```
-After that you will be able to work with your InfluxDB with web-interface at
-http://localhost:8086 . You can change it with
-[instruction](https://docs.influxdata.com/influxdb/v2.4/reference/urls/). Go to
-your site and create the account. Save your login organisation as environmental
-variable or in `.env` as `INFLUX_ORG`
-3. Go to `<localhost:8086> -> Load data -> Buckets` to create bucket. Save
-bucket name to environmental variable or in `.env` file as
-`INFLUX_BUCKET=<bucket>`
-4. Go to `<localhost:8086> -> Load data -> API Tokens` to get your token. Save
-token to environmental variable or in `.env` file as `INFLUX_TOKEN=<token>`
-5. Save your InfluxDB site to environmental variable or in `.env` file as
-`INFLUX_URL`
-6. If you've written variables to `.env`, run the following command:
-```bash
-source .env && export $(cut -d= -f1 .env)
-```
+InfluxDB is the database we use to store data and build dashboards. Our InfluxDB
+connector is in `multivac/influxdb.py`.
+
+Run and connect to InfluxDB locally
+-----------------------------------
+
+1.  Install InfluxDB 2 according to
+    `official instruction <https://docs.influxdata.com/influxdb/v2.4/install/>`__.
+
+2.  Launch InfluxDB:
+
+    ..  code-block:: console
+
+        $ influxd
+
+    After that you will be able to work with your InfluxDB with web-interface at
+    http://localhost:8086 . You can change it with
+    `instruction <https://docs.influxdata.com/influxdb/v2.4/reference/urls/>`__.
+    Go to your site and create the account. Save your login organisation as
+    environmental variable or in `.env` as `INFLUX_ORG`
+
+3.   Go to `<localhost:8086> -> Load data -> Buckets` to create bucket. Save
+     bucket name to environmental variable or in `.env` file as
+     `INFLUX_BUCKET=<bucket>`
+
+4.  Go to `<localhost:8086> -> Load data -> API Tokens` to get your token. Save
+    token to environmental variable or in `.env` file as `INFLUX_TOKEN=<token>`
+
+5.  Save your InfluxDB site to environmental variable or in `.env` file as
+    `INFLUX_URL`
+
+6.  If you've written variables to `.env`, run the following command:
+
+    ..  code-block:: console
+
+        $ source .env && export $(cut -d= -f1 .env)
 
 Now you are ready to start any python script using InfluxDB connector
+
+Using InfluxDB connector from code
+----------------------------------
+
+To use our connector from your code, import the connector:
+
+..  code-block:: python3
+
+    from multivac.influxdb import influx_connector
+    ...
+    bucket = os.getenv('INFLUX_BUCKET')
+    org = os.getenv('INFLUX_ORG')
+
+    write_api = influx_connector()
+    data = {
+        'measurement': <your_record_ID, required>,
+        'tags': {<'indexed key/value structure, not required'>},
+        'fields': {<'not indexed key/value structure, required'>},
+        'time': <'unix time in nanoseconds, not required'>
+    }
+    write_api.write(bucket, org, [data])
+
+InfluxDB connector in gather_job_data.py
+----------------------------------------
+
+-   **Measurement:** job ID;
+-   **Tags:** job_name, branch, commit_sha, platform, runner_label;
+-   **Fields:** status, started at, completed at;
+-   **Time:** queued at.
+
+Usage:
+
+..  code-block:: console
+
+    $ multivac/gather_job_data.py --format influxdb

--- a/docs/influxdb.rst
+++ b/docs/influxdb.rst
@@ -1,0 +1,27 @@
+How to connect to InfluxDB
+==========================
+
+1. Install InfluxDB 2 according to
+[official instruction](https://docs.influxdata.com/influxdb/v2.4/install/)
+2. Launch InfluxDB:
+```bash
+influxd
+```
+After that you will be able to work with your InfluxDB with web-interface at
+http://localhost:8086 . You can change it with
+[instruction](https://docs.influxdata.com/influxdb/v2.4/reference/urls/). Go to
+your site and create the account. Save your login organisation as environmental
+variable or in `.env` as `INFLUX_ORG`
+3. Go to `<localhost:8086> -> Load data -> Buckets` to create bucket. Save
+bucket name to environmental variable or in `.env` file as
+`INFLUX_BUCKET=<bucket>`
+4. Go to `<localhost:8086> -> Load data -> API Tokens` to get your token. Save
+token to environmental variable or in `.env` file as `INFLUX_TOKEN=<token>`
+5. Save your InfluxDB site to environmental variable or in `.env` file as
+`INFLUX_URL`
+6. If you've written variables to `.env`, run the following command:
+```bash
+source .env && export $(cut -d= -f1 .env)
+```
+
+Now you are ready to start any python script using InfluxDB connector

--- a/docs/toctree.rst
+++ b/docs/toctree.rst
@@ -5,3 +5,4 @@
 
     intro
     gather_job_data
+    influxdb

--- a/multivac/influxdb.py
+++ b/multivac/influxdb.py
@@ -1,0 +1,12 @@
+from os import getenv
+from influxdb_client import InfluxDBClient, WriteApi
+from influxdb_client.client.write_api import SYNCHRONOUS
+
+
+def influx_connector() -> WriteApi:
+    org = getenv('INFLUX_ORG')
+    token = getenv('INFLUX_TOKEN')
+    url = getenv('INFLUX_URL')
+
+    client = InfluxDBClient(url=url, token=token, org=org)
+    return client.write_api(write_options=SYNCHRONOUS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.27.1
+influxdb-client==1.31.0


### PR DESCRIPTION
This patch improves `multivac/gather_job_data.py` to store gathered
job data in InfluxDB. Credentials for connection must be set as
environment variables.

We use job id as uniq record identificator (`measurement`). The
following data set as tags:
* job name
* branch
* commit_sha
* runner platform
* runner label
* runner version
* runner name
* failure type
* status

The following data set as fields:
* time the job started at
* time the job completed at

Time the job queued at is taken as time for InfluxDB recording (Unix
time, nanoseconds)

Learn more in `docs/influxdb.rst`

Resolves #23