### PR TITLE
gather data: new bucket to create table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           INFLUX_JOB_BUCKET: ${{ secrets.INFLUX_JOB_BUCKET }}
           INFLUX_TEST_BUCKET: ${{ secrets.INFLUX_TEST_BUCKET }}
+          INFLUX_TABLE_BUCKET: ${{ secrets.INFLUX_TABLE_BUCKET }}
           INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
           INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
           INFLUX_URL: ${{ secrets.INFLUX_URL }}


### PR DESCRIPTION
This patch creates new data structure for new InfluxDB bucket to create
table view panel in Grafana: store links to commit, GH Action run job
page, run job log file, run job JSON file, workflow run JSON file.

Resolves https://github.com/tarantool/multivac/issues/2