### PR TITLE
ci: make test deploy to InfluxDB

### DIFF
--- a/.github/workflows/buckets-create.yml
+++ b/.github/workflows/buckets-create.yml
@@ -1,0 +1,60 @@
+name: Create test bucket
+
+on:
+  pull_request:
+      types: [ opened ]
+
+jobs:
+  create-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    strategy:
+      matrix:
+        label: ['tests', 'workflows', 'table']
+    env:
+        INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+        INFLUX_ORG: ${{ secrets.INFLUX_ORG_ID }}
+        INFLUX_URL: ${{ secrets.INFLUX_URL }}
+        BUCKET_BASE: '${{ github.head_ref }}-${{ matrix.label }}'
+
+    steps:
+      - name: Get bucket name (strip username)
+        run: |
+          echo 'BUCKET_NAME<<EOF' >> $GITHUB_ENV
+            echo ${BUCKET_BASE} | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Create bucket
+        run: |
+          # expire in 15 days
+          echo 'ARTIFACT_NAME<<EOF' >> $GITHUB_ENV
+          curl --request POST \
+            "https://influxdb.tarantool.io/api/v2/buckets" \
+            --header "Authorization: Token ${INFLUX_TOKEN}" \
+            --header "Content-type: application/json" \
+            --data '{
+              "orgID": "'"${INFLUX_ORG}"'",
+              "name": "${{ env.BUCKET_NAME }}",
+              "retentionRules": [
+                {
+                  "type": "expire",
+                  "everySeconds": 1296000,
+                  "shardGroupDurationSeconds": 0
+                }
+              ]
+            }' | jq '.id' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Save bucket ID
+        run: |
+          if [[ ${{ env.ARTIFACT_NAME }} ]]; then
+            echo ${{ env.ARTIFACT_NAME }} > ${{ env.BUCKET_NAME }}-id
+          else
+            exit 1
+          fi
+
+      - name: Fill the bucket
+        uses: ./.github/actions/write_to_db
+        with:
+          influx_token: ${{ secrets.INFLUX_TOKEN }}
+          influx_url: ${{ secrets.INFLUX_URL }}
+

--- a/.github/workflows/buckets-delete.yml
+++ b/.github/workflows/buckets-delete.yml
@@ -1,0 +1,38 @@
+name: Delete test bucket
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  delete-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    strategy:
+      matrix:
+        label: ['tests', 'workflows', 'table']
+    env:
+      INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+      INFLUX_ORG: ${{ secrets.INFLUX_ORG_ID }}
+      INFLUX_URL: ${{ secrets.INFLUX_URL }}
+      BUCKET_BASE: '${{ github.head_ref }}-${{ matrix.label }}'
+
+    steps:
+      - name: Get bucket name (strip username)
+        run: |
+          echo 'BUCKET_NAME<<EOF' >> $GITHUB_ENV
+            echo ${BUCKET_BASE} | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Get artefact
+        run: |
+          echo 'BUCKET_ID<<EOF' >> $GITHUB_ENV
+            cat ${{ env.BUCKET_NAME }}-id >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Delete bucket
+        run: |
+          curl --request DELETE \
+            "https://influxdb.tarantool.io/api/v2/buckets/${{ env.BUCKET_ID }}" \
+            --header "Authorization: Token ${INFLUX_TOKEN}" \
+            --header "Content-type: application/json"
+          rm ${{ env.BUCKET_NAME }}-id

--- a/.github/workflows/buckets-update.yml
+++ b/.github/workflows/buckets-update.yml
@@ -1,0 +1,72 @@
+name: Update test bucket
+
+on:
+  pull_request:
+    types: [ synchronize ]
+    paths:
+      - '.github/workflows/*'
+      - 'multivac/gather_data.py'
+      - 'multivac/influxdb.py'
+      - 'multivac/fetch.py'
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/*'
+      - 'multivac/gather_data.py'
+      - 'multivac/influxdb.py'
+      - 'multivac/fetch.py'
+
+jobs:
+  clear-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    strategy:
+      matrix:
+        label: ['tests', 'workflows', 'table']
+    env:
+      INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+      INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
+      INFLUX_URL: ${{ secrets.INFLUX_URL }}
+      BUCKET_BASE: '${{ github.head_ref }}-${{ matrix.label }}'
+
+    steps:
+      - name: Get bucket name (strip username)
+        run: |
+          if [[ '${{ github.event_name }}'=='pull_request' ]]; then
+            echo 'BUCKET_NAME<<EOF' >> $GITHUB_ENV
+              echo ${BUCKET_BASE} | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+            echo 'EOF' >> $GITHUB_ENV
+          else
+            echo 'BUCKET_NAME=multivac-${{ matrix.label }}' >> $GITHUB_ENV
+          fi
+
+      - name: Get start and stop time
+        run: |
+          echo 'START_TIME<<EOF' >> $GITHUB_ENV
+            date -d 'last month' -I >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+          echo 'STOP_TIME<<EOF' >> $GITHUB_ENV
+            date -I >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Clear the data
+        run: |
+          echo ${{ env.BUCKET_NAME }}
+          curl --request POST \
+            "https://influxdb.tarantool.io/api/v2/delete?org=${{ env.INFLUX_ORG }}&bucket=${{ env.BUCKET_NAME }}" \
+            --header 'Authorization: Token ${{ env.INFLUX_TOKEN }}' \
+            --header 'Content-Type: application/json' \
+            --data '{
+              "start": "${{ env.START_TIME }}T00:00:00Z",
+              "stop": "${{ env.STOP_TIME }}T23:59:00Z"
+            }'
+
+  write-data:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    needs: clear-bucket
+    steps:
+      - uses: ./.github/actions/write_to_db
+        with:
+          influx_token: ${{ secrets.INFLUX_TOKEN }}
+          influx_url: ${{ secrets.INFLUX_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,18 +32,11 @@ jobs:
         working-directory: /mnt/storage/multivac
 
       - name: write data to InfluxDB
-        env:
-          INFLUX_JOB_BUCKET: ${{ secrets.INFLUX_JOB_BUCKET }}
-          INFLUX_TEST_BUCKET: ${{ secrets.INFLUX_TEST_BUCKET }}
-          INFLUX_TABLE_BUCKET: ${{ secrets.INFLUX_TABLE_BUCKET }}
-          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
-          INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
-          INFLUX_URL: ${{ secrets.INFLUX_URL }}
-        run: |
-          source venv/bin/activate
-          pip install -r requirements.txt
-          ./multivac/gather_data.py -t --format influxdb --since 2d
-        working-directory: /mnt/storage/multivac
+        uses: ./.github/actiions/write_to_db
+        with:
+          influx_token: ${{ secrets.INFLUX_TOKEN }}
+          influx_url: ${{ secrets.INFLUX_URL }}
+          since: 2d
 
       - name: Set the chat for failure notification
         if: failure()


### PR DESCRIPTION
This patch adds three new workflows to create and fill, update (clear and re-fill) and delete buckets. Allows to test new data structure in Grafana without deployng to production and automates deploy new data structure in production.

Resolves #54