### PR TITLE
ci: make test deploy to InfluxDB

### DIFF
--- a/.github/actions/write_to_db/action.yml
+++ b/.github/actions/write_to_db/action.yml
@@ -1,0 +1,59 @@
+name: Write data to InfluxDB
+description: Gather workflow and test data with `gather_data.py` and write it to the InfluxDB
+
+inputs:
+  influx_token:
+    required: true
+    description: InfluxDB API token
+  influx_org:
+    required: false
+    default: tarantool
+    description: InfluxDB account organisathion
+  influx_url:
+    required: true
+    description: InfluxDB URL
+  since:
+    required: false
+    default: 30d
+    description: set `--since` option for `gather_data.py`. Format `#d|h`, 
+                  i.e. `30d`, `12h`
+
+runs:
+  using: composite
+  steps:
+    - name: Get bucket base
+      run: |
+        if [[ "${{ github.event_name }}"=="pull_request" ]]; then
+          echo 'DEPLOYMENT_NAME<<EOF' >> $GITHUB_ENV
+            echo '${{ github.head_ref }}' | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+          echo 'BRANCH=${{ github.head_ref }}' >> $GITHUB_ENV
+        else
+          echo 'DEPLOYMENT_NAME=multivac' >> $GITHUB_ENV
+          echo 'BRANCH=master' >> $GITHUB_ENV
+        fi
+      shell: bash
+
+    - name: Get bucket names
+      run: |
+        echo ${{ env.DEPLOYMENT_NAME }}
+        echo 'INFLUX_JOB_BUCKET=${{ env.DEPLOYMENT_NAME }}-workflows' >> $GITHUB_ENV
+        echo 'INFLUX_TEST_BUCKET=${{ env.DEPLOYMENT_NAME }}-tests' >> $GITHUB_ENV
+        echo 'INFLUX_TABLE_BUCKET=${{ env.DEPLOYMENT_NAME }}-table' >> $GITHUB_ENV
+      shell: bash
+
+    - name: Write data to InfluxDB
+      env:
+        INFLUX_JOB_BUCKET: ${{ env.INFLUX_JOB_BUCKET }}
+        INFLUX_TEST_BUCKET: ${{ env.INFLUX_TEST_BUCKET }}
+        INFLUX_TABLE_BUCKET: ${{ env.INFLUX_TABLE_BUCKET }}
+        INFLUX_TOKEN: ${{ inputs.influx_token }}
+        INFLUX_ORG: ${{ inputs.influx_org }}
+        INFLUX_URL: ${{ inputs.influx_url }}
+      run: |
+        git checkout ${{ env.BRANCH }}
+        source venv/bin/activate
+        pip install -r requirements.txt
+        ./multivac/gather_data.py -t --format influxdb --since ${{ inputs.since }}
+      working-directory: /mnt/storage/multivac
+      shell: bash

--- a/.github/workflows/aws-sync.yml
+++ b/.github/workflows/aws-sync.yml
@@ -1,4 +1,4 @@
-name: Update test stats
+name: Sync output with s3
 
 on:
   workflow_dispatch:
@@ -9,11 +9,21 @@ jobs:
   deploy:
     runs-on: ['self-hosted', 'multivac-crawler']
     steps:
+      - uses: actions/checkout@v3
       - name: Sync workflow_runs
         run: ./backup.sh workflow_runs
 
       - name: Sync workflow_run_jobs
         run: ./backup.sh workflow_run_jobs
+
+      - name: Set the chat for failure notification
+        if: failure()
+        run: |
+          if [[ $GITHUB_REF == 'refs/heads/master' ]]; then
+              echo "CHAT_ID=${{ secrets.MYTEAM_SERVICE_CHAT_ID }}" >> "$GITHUB_ENV"
+          else
+              echo "CHAT_ID=${{ secrets.MYTEAM_DEBUG_CHAT_ID }}" >> "$GITHUB_ENV"
+          fi
 
       - name: Send notification
         if: failure()

--- a/.github/workflows/buckets-create.yml
+++ b/.github/workflows/buckets-create.yml
@@ -1,0 +1,101 @@
+name: Create test bucket
+
+on:
+  pull_request:
+      types: [ opened, reopened ]
+      paths:
+        - '.github/workflows/buckets-*'
+        - '.github/action/write-to-db/action.yml'
+        - 'multivac/gather_data.py'
+        - 'multivac/influxdb.py'
+        - 'multivac/sensors/test_status.py'
+
+jobs:
+  create-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    strategy:
+      matrix:
+        label: ['tests', 'workflows', 'table']
+    env:
+        INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+        INFLUX_ORG: ${{ secrets.INFLUX_ORG_ID }}
+        INFLUX_URL: ${{ secrets.INFLUX_URL }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get deployment name
+        run: |
+          echo 'DEPLOYMENT_NAME<<EOF' >> $GITHUB_ENV
+            echo ${{ github.head_ref }} | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Get bucket name (strip username)
+        run: echo 'BUCKET_NAME=${{ env.DEPLOYMENT_NAME }}-${{ matrix.label }}' >> $GITHUB_ENV
+
+      - name: Create bucket
+        run: |
+          # expire in 30 days = 2592000 seconds
+          echo 'ARTIFACT_NAME<<EOF' >> $GITHUB_ENV
+          curl --request POST \
+            "${{ secrets.INFLUX_URL }}/api/v2/buckets" \
+            --header "Authorization: Token ${{ env.INFLUX_TOKEN }}" \
+            --header "Content-type: application/json" \
+            --data '{
+              "orgID": "'"${{ env.INFLUX_ORG }}"'",
+              "name": "${{ env.BUCKET_NAME }}",
+              "retentionRules": [
+                {
+                  "type": "expire",
+                  "everySeconds": 2592000,
+                  "shardGroupDurationSeconds": 0
+                }
+              ]
+            }' | jq '.id' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Save bucket ID
+        run: |
+          if [[ ${{ env.ARTIFACT_NAME != null }} ]]; then
+            echo ${{ env.ARTIFACT_NAME }} > ${{ env.BUCKET_NAME }}-id
+          else
+            exit 1
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BUCKET_NAME }}-id
+          path: ${{ env.BUCKET_NAME }}-id
+
+  fill-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    needs: create-bucket
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fill the bucket
+        uses: ./.github/actions/write_to_db
+        with:
+          influx_token: ${{ secrets.INFLUX_TOKEN }}
+          influx_url: ${{ secrets.INFLUX_URL }}
+          deployment_url: ${{ secrets.DEPLOYMENT_URL }}
+
+      - name: start deployment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: dev-${{ env.DEPLOYMENT_NAME }}
+          ref: ${{ github.head_ref }}
+
+      - name: update deployment status
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ github.token }}
+          env: dev-${{ env.DEPLOYMENT_NAME }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ secrets.DEPLOYMENT_URL }}&var-bucket=${{ env.INFLUX_TEST_BUCKET }}&var-bucket_table=${{ env.INFLUX_TABLE_BUCKET }}

--- a/.github/workflows/buckets-delete.yml
+++ b/.github/workflows/buckets-delete.yml
@@ -1,0 +1,59 @@
+name: Delete test bucket
+
+on:
+  pull_request:
+    types: [ closed ]
+    paths:
+      - '.github/workflows/buckets-*'
+      - '.github/action/write-to-db/action.yml'
+      - 'multivac/gather_data.py'
+      - 'multivac/influxdb.py'
+      - 'multivac/sensors/test_status.py'
+
+jobs:
+  delete-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    strategy:
+      matrix:
+        label: ['tests', 'workflows', 'table']
+    env:
+      INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+      INFLUX_ORG: ${{ secrets.INFLUX_ORG_ID }}
+      INFLUX_URL: ${{ secrets.INFLUX_URL }}
+
+    steps:
+      - name: Get deployment name
+        run: |
+          echo 'DEPLOYMENT_NAME<<EOF' >> $GITHUB_ENV
+            echo ${{ github.head_ref }} | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Get bucket name (strip username)
+        run: echo 'BUCKET_NAME=${{ env.DEPLOYMENT_NAME }}-${{ matrix.label }}' >> $GITHUB_ENV
+
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: buckets-create.yml
+          branch: ${{ github.head_ref }}
+          name: ${{ env.BUCKET_NAME }}-id
+
+      - name: Get bucket ID
+        run: |
+          echo 'BUCKET_ID<<EOF' >> $GITHUB_ENV
+            cat ${{ env.BUCKET_NAME }}-id >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Delete bucket
+        run: |
+          curl --request DELETE \
+            "${{ secrets.INFLUX_URL }}/api/v2/buckets/${{ env.BUCKET_ID }}" \
+            --header "Authorization: Token ${{ env.INFLUX_TOKEN }}" \
+            --header "Content-type: application/json"
+
+      - name: Remove GitHub deployment at branch-${{ env.DEPLOYMENT_NAME }}
+        uses: bobheadxi/deployments@v1
+        with:
+          step: delete-env
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: dev-${{ env.DEPLOYMENT_NAME }}
+

--- a/.github/workflows/buckets-update.yml
+++ b/.github/workflows/buckets-update.yml
@@ -1,0 +1,94 @@
+name: Update test bucket
+
+on:
+  pull_request:
+    types: [ synchronize ]
+    paths:
+      - '.github/workflows/buckets-*'
+      - '.github/action/write-to-db/action.yml'
+      - 'multivac/gather_data.py'
+      - 'multivac/influxdb.py'
+      - 'multivac/sensors/test_status.py'
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/buckets-*'
+      - '.github/action/write-to-db/action.yml'
+      - 'multivac/gather_data.py'
+      - 'multivac/influxdb.py'
+      - 'multivac/sensors/test_status.py'
+
+jobs:
+  clear-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    strategy:
+      matrix:
+        label: ['tests', 'workflows', 'table']
+    env:
+      INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+      INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
+      INFLUX_URL: ${{ secrets.INFLUX_URL }}
+
+    steps:
+      - name: Get deployment name
+        run: |
+          echo 'DEPLOYMENT_NAME<<EOF' >> $GITHUB_ENV
+            echo ${{ github.head_ref }} | sed -r 's/^.*\/(.*)/\1/' >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Get bucket name (strip username)
+        run: echo 'BUCKET_NAME=${{ env.DEPLOYMENT_NAME }}-${{ matrix.label }}' >> $GITHUB_ENV
+
+      - name: Get start and stop time
+        run: |
+          echo 'START_TIME<<EOF' >> $GITHUB_ENV
+            date -d 'last month' -I >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+          echo 'STOP_TIME<<EOF' >> $GITHUB_ENV
+            date -I >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Clear the data
+        run: |
+          echo ${{ env.BUCKET_NAME }}
+          curl --request POST \
+            "${{ secrets.INFLUX_URL }}/api/v2/delete?org=${{ env.INFLUX_ORG }}&bucket=${{ env.BUCKET_NAME }}" \
+            --header 'Authorization: Token ${{ env.INFLUX_TOKEN }}' \
+            --header 'Content-Type: application/json' \
+            --data '{
+              "start": "${{ env.START_TIME }}T00:00:00Z",
+              "stop": "${{ env.STOP_TIME }}T23:59:00Z"
+            }'
+
+  fill-bucket:
+    runs-on: ['self-hosted', 'multivac-crawler']
+    needs: clear-bucket
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/write_to_db
+        with:
+          influx_token: ${{ secrets.INFLUX_TOKEN }}
+          influx_url: ${{ secrets.INFLUX_URL }}
+
+      - name: start deployment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: dev-${{ env.DEPLOYMENT_NAME }}
+          ref: ${{ github.head_ref }}
+
+      - name: update deployment status
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: bobheadxi/deployments@v1
+        with:
+          step: finish
+          token: ${{ github.token }}
+          env: dev-${{ env.DEPLOYMENT_NAME }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ secrets.DEPLOYMENT_URL }}&var-bucket=${{ env.INFLUX_TEST_BUCKET }}&var-bucket_table=${{ env.INFLUX_TABLE_BUCKET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       LOG_STORAGE_BUCKET_URL: ${{ secrets.LOG_STORAGE_BUCKET_URL }}
     steps:
+      - uses: actions/checkout@v3
       - name: update repo
         run: git checkout master && git fetch && git reset --hard origin/master
         working-directory: /mnt/storage/multivac
@@ -32,18 +33,11 @@ jobs:
         working-directory: /mnt/storage/multivac
 
       - name: write data to InfluxDB
-        env:
-          INFLUX_JOB_BUCKET: ${{ secrets.INFLUX_JOB_BUCKET }}
-          INFLUX_TEST_BUCKET: ${{ secrets.INFLUX_TEST_BUCKET }}
-          INFLUX_TABLE_BUCKET: ${{ secrets.INFLUX_TABLE_BUCKET }}
-          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
-          INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
-          INFLUX_URL: ${{ secrets.INFLUX_URL }}
-        run: |
-          source venv/bin/activate
-          pip install -r requirements.txt
-          ./multivac/gather_data.py -t --format influxdb --since 2d
-        working-directory: /mnt/storage/multivac
+        uses: ./.github/actiions/write_to_db
+        with:
+          influx_token: ${{ secrets.INFLUX_TOKEN }}
+          influx_url: ${{ secrets.INFLUX_URL }}
+          since: 2d
 
       - name: Set the chat for failure notification
         if: failure()


### PR DESCRIPTION
This patch adds three new workflows to create and fill, update (clear and re-fill) and delete buckets. Allows to test new data structure in Grafana without deployng to production and automates deploy new data structure to production.

Resolves #54