### PR TITLE
gather_data: fix os_version collection for table bucket

### DIFF
--- a/.github/actions/write_to_db/action.yml
+++ b/.github/actions/write_to_db/action.yml
@@ -51,7 +51,9 @@ runs:
         INFLUX_ORG: ${{ inputs.influx_org }}
         INFLUX_URL: ${{ inputs.influx_url }}
       run: |
+        git fetch --prune
         git checkout ${{ env.BRANCH }}
+        git reset --hard origin/${{ env.BRANCH }}
         source venv/bin/activate
         pip install -r requirements.txt
         ./multivac/gather_data.py -t --format influxdb --since ${{ inputs.since }}

--- a/.github/workflows/buckets-create.yml
+++ b/.github/workflows/buckets-create.yml
@@ -55,7 +55,10 @@ jobs:
 
       - name: Save bucket ID
         run: |
-          if [[ ${{ env.ARTIFACT_NAME != null }} ]]; then
+          # bucket ID can't be less than 16 bytes
+          id=${{ env.ARTIFACT_NAME }}
+          len_id=${#id}
+          if [ ${len_id} -gt 15 ]; then
             echo ${{ env.ARTIFACT_NAME }} > ${{ env.BUCKET_NAME }}-id
           else
             exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
     env:
       LOG_STORAGE_BUCKET_URL: ${{ secrets.LOG_STORAGE_BUCKET_URL }}
     steps:
-      - uses: actions/checkout@v3
       - name: update repo
         run: git checkout master && git fetch && git reset --hard origin/master
         working-directory: /mnt/storage/multivac
@@ -32,12 +31,19 @@ jobs:
         run: ./multivac/last_seen.py --branch master --branch 1.10 --branch 2.10
         working-directory: /mnt/storage/multivac
 
-      - name: write data to InfluxDB
-        uses: ./.github/actiions/write_to_db
-        with:
-          influx_token: ${{ secrets.INFLUX_TOKEN }}
-          influx_url: ${{ secrets.INFLUX_URL }}
-          since: 2d
+      - name: Write data to InfluxDB
+        env:
+          INFLUX_JOB_BUCKET: ${{ secrets.INFLUX_JOB_BUCKET }}
+          INFLUX_TEST_BUCKET: ${{ secrets.INFLUX_TEST_BUCKET }}
+          INFLUX_TABLE_BUCKET: ${{ secrets.INFLUX_TABLE_BUCKET }}
+          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
+          INFLUX_ORG: ${{ secrets.INFLUX_ORG }}
+          INFLUX_URL: ${{ secrets.INFLUX_URL }}
+        run: |
+          source venv/bin/activate
+          pip install -r requirements.txt
+          ./multivac/gather_data.py -t --format influxdb --since 2d
+        working-directory: /mnt/storage/multivac
 
       - name: Set the chat for failure notification
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ workflow_run_jobs
 # Python bytecode.
 *.pyc
 __pycache__
+venv
 
 # IDEA
 .idea

--- a/multivac/gather_data.py
+++ b/multivac/gather_data.py
@@ -422,7 +422,7 @@ class GatherData:
                     'branch': job_info['branch'],
                     'architecture': job_info['platform'],
                     'gc64': job_info['gc64'],
-                    'os_version': job_info['runner_label'][0],
+                    'os_version': job_info['os_version'],
                     'job_link': job_info['html_url'].lstrip('https://'),
                     'commit_link': f"{base_url}/commit/{job_info['commit_sha']}",
                     'job_json': f"{s3_url}/workflow_run_jobs/{job_id}.json",


### PR DESCRIPTION
[gather_data: fix os_version collection for table bucket](https://github.com/tarantool/multivac/pull/76/commits/2d86ca4d0341c929f795c42a833519c8084c321f)
Store os version, not runner label
 
[gitignore: added venv to gitignore](https://github.com/tarantool/multivac/pull/76/commits/8b4432ea68af6d0a71212a10bcd660f5d707c0af)

 
[ci: fix branch update for test deploy](https://github.com/tarantool/multivac/pull/76/commits/06c8f31c783cb5793ddf8a5960eb65c36ba6e666)
Branch update was incorrect, this patch fixes it

PR tests:
- [x] Creating bucket on PR open
- [x] Updating bucket when PR changed
- [x] Updating data, write data with different data structure, deleting tag, adding tag
- [x] Deleting bucket on PR closed