### PR TITLE
gather_data: fix tagging for jobs

### DIFF
--- a/.github/workflows/buckets-update.yml
+++ b/.github/workflows/buckets-update.yml
@@ -11,6 +11,8 @@ on:
       - 'multivac/sensors/test_status.py'
   workflow_dispatch:
   push:
+    branches:
+      - 'master'
     paths:
       - '.github/workflows/buckets-*'
       - '.github/action/write-to-db/action.yml'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,7 +1,10 @@
 name: testing
 
-on: [push, pull_request]
-
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
 jobs:
   flake8:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This patch fixes tagging:

* For freebsd - added matcher to get correct runner version
* For all the jobs - if there are no data for any tag, store 'None'

This will help to show correct data on filtered Grafana