### PR TITLE
ci: fix aws-sync.yml

### DIFF
--- a/.github/workflows/aws-sync.yml
+++ b/.github/workflows/aws-sync.yml
@@ -1,6 +1,9 @@
 name: Sync output with s3
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/aws-sync.yml'
   workflow_dispatch:
   schedule:
     - cron: 30 20 * * *

--- a/backup.sh
+++ b/backup.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -xe o pipefail -o nounset
 
 if [ $# -eq 0 ]; then
     echo "usage: $0 dir" 1>&2
@@ -8,6 +7,7 @@ fi
 
 DIR="$1"
 
+set -xe o pipefail -o nounset
 /usr/local/bin/aws \
   s3 sync /mnt/storage/multivac/${DIR} \
   s3://multivac/tarantool/tarantool/${DIR} \


### PR DESCRIPTION
Fix problem with aws-sync: https://github.com/tarantool/multivac/actions/runs/3372709498

```
Run ./backup.sh workflow_runs
  ./backup.sh workflow_runs
  shell: /usr/bin/bash -e {0}
+ [ 4 -eq 0 ]
+ DIR=o
+ /usr/local/bin/aws s3 sync /mnt/storage/multivac/o s3://multivac/tarantool/tarantool/o --endpoint-url http://hb.bizmrg.com/ --acl public-read

The user-provided path /mnt/storage/multivac/o does not exist.
Error: Process completed with exit code 255.
```

- [x] job tested