### PR TITLE
gather_data: add compiler version

### DIFF
--- a/multivac/sensors/test_status.py
+++ b/multivac/sensors/test_status.py
@@ -33,12 +33,6 @@ HANG_RESULT_RE = re.compile(
     TIMESTAMP_RE + SEP_RE +
     r'--- ' + RESULT_RE + r'\b')
 
-COLOR_RE = re.compile('\033' + r'\[\d(?:;\d\d)?m')
-
-
-def decolor(data):
-    return COLOR_RE.sub('', data)
-
 
 def get_cache_filepath(log_filepath):
     return '{}.test_status.cache.json'.format(log_filepath)
@@ -64,8 +58,7 @@ def test_status_iter(log_fh, cache_filepath=None):
         cache = []
 
     hang_detected = False
-    for unprocessed_line in log_fh:
-        line = decolor(unprocessed_line)
+    for line in log_fh:
         m = TEST_STATUS_LINE_RE.match(line)
         if m:
             status = m.group('status') or 'fail'


### PR DESCRIPTION
This patch adds compiler version from logs and glibc version from
static dict GLIBC_MAPER to JSON and to the InfluxDB tests bucket.

Resolves https://github.com/tarantool/multivac/issues/84