### PR TITLE
multivac: store each repo data in separate dirs

### DIFF
--- a/.github/workflows/aws-sync.yml
+++ b/.github/workflows/aws-sync.yml
@@ -10,14 +10,15 @@ on:
 
 jobs:
   deploy:
+    strategy:
+      matrix:
+        repo: [ 'tarantool/tarantool', 'tarantool/tarantool-ee' ]
+        dir: [ 'artifacts', 'workflow_runs', 'workflow_run_jobs' ]
     runs-on: ['self-hosted', 'multivac-crawler']
     steps:
       - uses: actions/checkout@v3
-      - name: Sync workflow_runs
-        run: ./backup.sh workflow_runs
-
-      - name: Sync workflow_run_jobs
-        run: ./backup.sh workflow_run_jobs
+      - name: Sync fetched data
+        run: ./backup.sh ${{ matrix.repo }}/${{ matrix.dir }}
 
       - name: Set the chat for failure notification
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   deploy:
+    strategy:
+      matrix:
+        repo: [ 'tarantool/tarantool', 'tarantool/tarantool-ee' ]
     runs-on: ['self-hosted', 'multivac-crawler']
     env:
       LOG_STORAGE_BUCKET_URL: ${{ secrets.LOG_STORAGE_BUCKET_URL }}
@@ -16,11 +19,11 @@ jobs:
         working-directory: /mnt/storage/multivac
 
       - name: fetch.py for master
-        run: ./multivac/fetch.py --branch master tarantool/tarantool
+        run: ./multivac/fetch.py --branch master ${{ matrix.repo }}
         working-directory: /mnt/storage/multivac
 
       - name: fetch.py for 2.10
-        run: ./multivac/fetch.py --branch 2.10 tarantool/tarantool
+        run: ./multivac/fetch.py --branch 2.10 ${{ matrix.repo }}
         working-directory: /mnt/storage/multivac
 
       - name: fetch.py for 1.10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,10 @@ jobs:
         run: ./multivac/fetch.py --branch 1.10 tarantool/tarantool
         working-directory: /mnt/storage/multivac
 
+      - name: get_artifacts.py
+        run: ./multivac/get_artifacts.py ${{ matrix.repo }}
+        working-directory: /mnt/storage/multivac
+
       - name: make csv
         run: ./multivac/last_seen.py --branch master --branch 1.10 --branch 2.10
         working-directory: /mnt/storage/multivac

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ token.txt
 .env
 
 # Fetched metainfo, logs, cached data views.
+tarantool
 workflow_runs
 workflow_run_jobs
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ SYNOPSIS
 DESCRIPTION
 
     multivac/fetch.py — download workflow runs GitHub API, workflow run jobs
-    GitHub API and logs. Result stored in `workflow_runs` and `workflow_run_jobs`
-    directories in the root of the project.
+    GitHub API and logs. Result stored in `<owner>/<repo>/workflow_runs` and 
+    `<owner>/<repo>/workflow_run_jobs` directories in the root of the project.
 
 
 OPTIONS
@@ -64,7 +64,8 @@ DESCRIPTION
    
     multivac/last_seen.py - generate common report from data collected by 
     `multivac/fetch.py` and store it in `output` directory. By default, it
-    generates a report in CSV format.
+    generates a report in CSV format. To start locally, set some value as
+    'LOG_STORAGE_BUCKET_URL' - uses as a value in result file.
 
 OPTIONS
 
@@ -80,13 +81,20 @@ OPTIONS
 
             Coalesce 'runs-on' labels by a first word
 
+    --repo-path
+    
+            owner/repository
+            Uses in `fetch.py` result files path, so `last_seen.py` needs it to
+            find data for certain repo. Default: 'tarantool/tarantool'. You can
+            set only one repo in one sckript start.
+
 EXAMPLE
 
     Generate a report in the HTML format for branches `master` and
-    `sample-branch`:
+    `sample-branch` for repo 'tarantool/multivac':
 
 ```console
-$ ./multivac/last_seen.py --branch master --branch sample-branch --format html
+$ ./multivac/last_seen.py --branch master --branch sample-branch --format html --repo-path tarantool/multivac
 ```
 
 ### gather_data.py
@@ -130,13 +138,21 @@ OPTIONS
             Only take logs for jobs started N days or hours ago: Nd for N days
             and Nh for N hours.
 
+    --repo-path
+    
+            repository (without owner)
+            Uses in `fetch.py` result files path, so `gather_data.py` needs it
+            to find data for certain repo. Default: 'tarantool/tarantool'.
+            You can set only one repo in one sckript start.
+
 EXAMPLE
     
-    Collect data about jobs and tests started a week ago or later, and put
-    this data to InfluxDB:
+    Collect data about jobs and tests started a week ago or later in repo 
+    'tarantool/multivac' (so the fetched JSON and log files stored in the path
+    ./tarantool/multivc), and put this data to InfluxDB:
 
 ```console
-$ ./multivac/gather_data.py -t --since 7d --format influxdb
+$ ./multivac/gather_data.py -t --since 7d --format influxdb --repo-path tarantool/multivac
 ```
 
 ### gather_test_data.py

--- a/multivac/fetch.py
+++ b/multivac/fetch.py
@@ -41,8 +41,8 @@ session.headers.update({
     'Authorization': 'token ' + token,
 })
 debug_log_fh = open('debug.log', 'a')
-workflow_runs_dir = 'workflow_runs'
-workflow_run_jobs_dir = 'workflow_run_jobs'
+workflow_runs_dir = f'{args.repo_path}/workflow_runs'
+workflow_run_jobs_dir = f'{args.repo_path}/workflow_run_jobs'
 
 
 def retry(http_get_function):

--- a/multivac/get_artifacts.py
+++ b/multivac/get_artifacts.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+import argparse
+import glob
+import os
+import json
+import requests
+
+
+def cli_parser():
+    parser = argparse.ArgumentParser(
+        description='Download artifact zip archives from GitHub Actions. Needs'
+                    '`fetch.py` first.'
+    )
+    parser.add_argument(
+        '--repo-path', type=str, default='tarantool/tarantool',
+        help='Owner/repository to get path to workflow run JSON files. '
+             'Default tarantool/tarantool'
+    )
+    parser.add_argument(
+        '--token-path', default='token.txt',
+        help='Path to Personal Access Token, see more in "How to use" in README'
+    )
+
+    return parser.parse_args()
+
+
+class BasicAuthToken(requests.auth.AuthBase):
+    def __init__(self, token):
+        self.token_file = token
+        self.token = self.__get_the_token()
+
+    def __call__(self, r):
+        r.headers.update({
+            'Accept': 'application/vnd.github.v3+json',
+            'Authorization': f'token {self.token}',
+        })
+        return r
+
+    def __is_token_valid(self):
+        if not os.path.exists(self.token_file):
+            raise RuntimeError(f'{self.token_file} is not exists')
+        if not os.path.isfile(self.token_file):
+            raise RuntimeError(
+                f'{self.token_file} is not a regular file')
+        return True
+
+    def __get_the_token(self):
+        assert self.__is_token_valid()
+        with open(self.token_file, 'r') as f:
+            token = f.read().strip()
+        return token
+
+
+class GitHubConnector:
+    def __init__(self, token):
+        self.session: requests.Session = requests.Session()
+        self.session.auth = BasicAuthToken(token)
+        self.timeout = 15
+
+    def get_workflow_run_artifacts(self, artifacts_api_url):
+        """
+        Here we get response from GitHub REST API:
+        If the result is OK, but there are no artifacts:
+            status code: 200
+            content:
+                {'total_count': 0, 'artifacts': []}
+
+        If the result OK and there are some artifacts:
+            status code: 200
+            the content see
+            https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts
+
+        If there are bad credentials:
+            status code: 401
+            content: {
+                'message': 'Bad credentials',
+                'documentation_url': 'https://docs.github.com/rest'
+                }
+
+        If the PAT rate limit exceeded:
+            status code: 403
+            content: {
+                'message': "API rate limit exceeded for 10.10.10.10.
+                (But here's the good news:
+                Authenticated requests get a higher rate limit.
+                Check out the documentation for more details.)",
+                'documentation_url':
+                'https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting'
+                }
+        """
+        try:
+            workflow_run_artifacts_data = self.session.get(artifacts_api_url,
+                                                           timeout=self.timeout)
+        except requests.exceptions.ReadTimeout:
+            print(f"Connection timeout error to get artifacts data "
+                  f"for {artifacts_api_url}")
+            return []
+
+        if workflow_run_artifacts_data.status_code == 200:
+            return workflow_run_artifacts_data.json(
+            ).get('artifacts', [])
+        print(f'ERROR: Unable to get artifacts list: '
+              f'{workflow_run_artifacts_data.text}')
+        return None
+
+    def get_artifacts(self,
+                      artifact_archive_download_url: str):
+        """
+        If the download link is OK, we get response status code 200 and
+        zip-archive as binary data in response content.
+        If there is something wrong, we will get response status code 4xx.
+        """
+        try:
+            download_response = self.session.get(artifact_archive_download_url,
+                                                 timeout=self.timeout)
+        except requests.exceptions.ReadTimeout:
+            print(f"Connection timeout error to download artifacts archive for "
+                  f"{artifact_archive_download_url}")
+            return False
+        if download_response.status_code != 200:
+            print(f"WARN: Can't download artifact from "
+                  f"{artifact_archive_download_url}. \n"
+                  f"Response status code: {download_response.status_code}. \n"
+                  f"Response text: {download_response.text}")
+            return False
+        return download_response
+
+
+def get_workflow_run_artifact_base_data(workflow_run_file):
+    with open(workflow_run_file, 'r') as f:
+        run_json = json.load(f)
+        artifacts_api_url = run_json.get('artifacts_url')
+        workflow_run_id = run_json.get('id')
+    return artifacts_api_url, workflow_run_id
+
+
+if __name__ == '__main__':
+    args = cli_parser()
+    github = GitHubConnector(args.token_path)
+    artifacts_dir = f'{args.repo_path}/artifacts'
+    workflow_runs_dir = f'{args.repo_path}/workflow_runs'
+    workflow_run_files = glob.glob(
+        os.path.join(workflow_runs_dir, '*[0-9].json'))
+
+    os.makedirs(artifacts_dir, exist_ok=True)
+
+    for run_file in workflow_run_files:
+        artifact_api_url, run_id = get_workflow_run_artifact_base_data(run_file)
+
+        if not artifact_api_url:
+            continue
+
+        artifacts_list = github.get_workflow_run_artifacts(artifact_api_url)
+
+        if artifacts_list is None:
+            exit(1)
+        if not artifacts_list:
+            continue
+
+        os.makedirs(f'{artifacts_dir}/{run_id}', exist_ok=True)
+
+        for artifact in artifacts_list:
+            path_to_file = f'{artifacts_dir}/{run_id}/{artifact["id"]}.zip'
+            artifact_download_response = github.get_artifacts(
+                artifact["archive_download_url"])
+
+            if artifact_download_response:
+                with open(path_to_file, 'wb') as f:
+                    f.write(artifact_download_response.content)

--- a/multivac/last_seen.py
+++ b/multivac/last_seen.py
@@ -10,11 +10,11 @@ import argparse
 import importlib.resources as pkg_resources
 
 # secret.LOG_STORAGE_BUCKET_URL
-bucket_url = os.environ.get('LOG_STORAGE_BUCKET_URL').strip("'")
-if not bucket_url:
+bucket_url_unstripped = os.environ.get('LOG_STORAGE_BUCKET_URL')
+if not bucket_url_unstripped:
     print('LOG_STORAGE_BUCKET_URL not set')
     exit(1)
-org_repo = 'tarantool/tarantool'
+bucket_url = bucket_url_unstripped.strip("'")
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(PROJECT_DIR)
@@ -30,13 +30,16 @@ parser.add_argument('--format', choices=['csv', 'html'], default='csv',
                     help='result format')
 parser.add_argument('--short', action='store_true',
                     help="Coalesce 'runs-on' labels by a first word")
+parser.add_argument('--repo-path', type=str, default='tarantool/tarantool',
+                    help='owner/repository')
 args = parser.parse_args()
 branch_list = args.branch
 result_format = args.format
 
 output_dir = 'output'
-workflow_runs_dir = 'workflow_runs'
-workflow_run_jobs_dir = 'workflow_run_jobs'
+workflow_runs_dir = f'{args.repo_path}/workflow_runs'
+workflow_run_jobs_dir = f'{args.repo_path}/workflow_run_jobs'
+org_repo = args.repo_path
 
 
 def fails(log):


### PR DESCRIPTION
Download artifacts, save them to S3 bucket
Store data in the path '\<owner\>/\<repo\>/workflow_runs' and '\<owner\>/\<repo\>/workflow_run_jobs' to work with several repositories.
Store data from both tarantool/tarantool and tarantool/tarantool-ee
repositories to S3 bucket.

Resolves https://github.com/tarantool/multivac/issues/97
Resolves https://github.com/tarantool/multivac/issues/94