### PR TITLE
gather_data: fix LIBC detection

### DIFF
--- a/multivac/gather_data.py
+++ b/multivac/gather_data.py
@@ -22,6 +22,7 @@ COMPILER_RE = re.compile(r'C compiler identification is '
 
 # According to distrowatch.com and repology.org/project/glibc/versions
 LIBC_VERSIONS = {
+    'apline_3_16': 'musl',
     'centos_7': '2.17',
     'centos_8': '2.28',
     'debian_9': '2.24',
@@ -353,7 +354,7 @@ class GatherData:
                 'runner_version': runner_version or "unknown",
                 'failure_type': job_failure_type or "not_failed",
                 'compiler_version': compiler,
-                'libc_version': LIBC_VERSIONS[os_version] or 'failed_to_detect',
+                'libc_version': LIBC_VERSIONS.get(os_version) or 'failed_to_detect',
             }
 
             if test_data:

--- a/multivac/get_artifacts.py
+++ b/multivac/get_artifacts.py
@@ -147,6 +147,11 @@ if __name__ == '__main__':
     for run_file in workflow_run_files:
         artifact_api_url, run_id = get_workflow_run_artifact_base_data(run_file)
 
+        # If the directory exists, we've already downloaded
+        # artifacts for this run
+        if os.path.exists(f'{artifacts_dir}/{run_id}'):
+            continue
+
         if not artifact_api_url:
             continue
 


### PR DESCRIPTION
Before this patch, `gather_data` failed when there was an OS version
not in the LIBC_VERSIONS dict. This patch fixes it. Also in this patch
added libc version (musl) for alpine_3_16