### PR TITLE
gather_data: add compiler and libc tags to table

### DIFF
--- a/multivac/gather_data.py
+++ b/multivac/gather_data.py
@@ -488,6 +488,8 @@ class GatherData:
                     'architecture': job_info['platform'],
                     'gc64': job_info['gc64'],
                     'os_version': job_info['os_version'],
+                    'compiler_version': job_info['compiler_version'],
+                    'libc_version': job_info['libc_version'],
                     'repository': self.repo_path,
                     'job_link': job_info['html_url'].lstrip('https://'),
                     'commit_link': f"{base_url}/commit/{job_info['commit_sha']}",


### PR DESCRIPTION
This patch adds tags 'compiler_version' and 'libc_version' to the table with data about failed tests to enable filter in Grafana