### PR TITLE
fetch.py: don't fall with error if no content-type

### DIFF
--- a/multivac/fetch.py
+++ b/multivac/fetch.py
@@ -91,19 +91,21 @@ def http_get(url, params=None):
 
     debug('Response HTTP status: {}', r.status_code)
     debug('Response headers:\n{}', json.dumps(dict(r.headers), indent=2))
-    content_type = r.headers['content-type']
-    if 'content-type'.startswith('application/json'):
-        response_text = json.dumps(r.json(), indent=2)
-    elif content_type == 'application/zip' or \
-            content_type.startswith('text/plain'):
-        fmt = '[Don\'t log {} response.]'
-        response_text = fmt.format(content_type)
+    content_type = r.headers.get('content-type')
+    if content_type:
+        if content_type.startswith('application/json'):
+            response_text = json.dumps(r.json(), indent=2)
+        elif content_type == 'application/zip' or content_type.startswith('text/plain'):
+            fmt = '[Don\'t log {} response.]'
+            response_text = fmt.format(content_type)
+        else:
+            fmt = '[Don\'t log response with unknown Content-Type: {}]'
+            response_text = fmt.format(content_type)
+        r.raise_for_status()
     else:
-        fmt = '[Don\'t log response with unknown Content-Type: {}]'
-        response_text = fmt.format(content_type)
-    debug('Response:\n{}', response_text)
+        response_text = '[EMPTY LOG!]'
 
-    r.raise_for_status()
+    debug('Response:\n{}', response_text)
 
     return r
 


### PR DESCRIPTION
There are some errors if the run log is empty:
```
Traceback (most recent call last):
  File "./multivac/fetch.py", line 410, in <module>
    job.download_log()
  File "./multivac/fetch.py", line 234, in download_log
    r = http_get(url)
  File "./multivac/fetch.py", line 53, in wrapper
    return http_get_function(*args, **kwargs)
  File "./multivac/fetch.py", line 94, in http_get
    content_type = r.headers['content-type']
  File "/usr/lib/python3/dist-packages/requests/structures.py", line 52, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'content-type'
```
So for now we need to change the method to get header value, so the script won't fail. Need further work to find why the logs are empty.

Related to https://github.com/tarantool/multivac/issues/113