### PR TITLE
ci, gather_data: minor improvements, bug fixes

### DIFF
--- a/.github/workflows/buckets-delete.yml
+++ b/.github/workflows/buckets-delete.yml
@@ -51,7 +51,7 @@ jobs:
             --header "Content-type: application/json"
 
       - name: Remove GitHub deployment at branch-${{ env.DEPLOYMENT_NAME }}
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@v1.3.0
         with:
           step: delete-env
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/multivac/gather_data.py
+++ b/multivac/gather_data.py
@@ -287,18 +287,6 @@ class GatherData:
             else:
                 gc64 = 'False'
 
-            # Take data from GitHub Workflow runs API
-            run_file_path = f"{self.workflow_runs_dir}/{job['run_id']}.json"
-            try:
-                with open(run_file_path) as run_file:
-                    run = json.load(run_file)
-                    branch = run['head_branch']
-            except FileNotFoundError:
-                print(f"Job {job_id}: no runs found, can't open "
-                      f"{run_file_path}")
-            except ValueError:
-                print(f"Job {job_id}: can't decode JSON in {run_file_path}")
-
             # Load info about jobs and tests from .log, if there are logs
             logs = f'{self.workflow_run_jobs_dir}/{job_id}.log'
             job_failure_type = None
@@ -339,7 +327,7 @@ class GatherData:
                 'workflow_run_id': job['run_id'],
                 'job_name': job['name'],
                 'os_version': os_version,
-                'branch': branch,
+                'branch': job['head_branch'],
                 'commit_sha': job['head_sha'],
                 'conclusion': job['conclusion'],
                 'queued_at': time_queued,


### PR DESCRIPTION
gather_data: don't fail if there are no log

If there are failed job with no log file, the `gather_data` script
fails:

```
Traceback (most recent call last):
  File "./multivac/gather_data.py", line 595, in <module>
    result.gather_data()
  File "./multivac/gather_data.py", line 309, in gather_data
    job_failure_type, failure_line = detect_error(logs,
  File "./multivac/gather_data.py", line 92, in detect_error
    for number, line in enumerate(reverse_readline(logs)):
  File "./multivac/gather_data.py", line 57, in reverse_readline
    with open(filename, encoding='utf8') as fh:
FileNotFoundError: [Errno 2] No such file or directory: 'tarantool/tarantool/workflow_run_jobs/11814288555.log'
```

This patch fixes this problem.

__________________________________________

ci: fix buckets-delete on step delete-env

Since bobheadxi/deployments@v1.4.0 we had a CI failure with the
following error in `buckets-delete` workflow, `delete-env` step:
```
unexpected error encountered: HttpError: Resource not accessible by integration
```
This patch returns version 1.3.0 that worked OK.

__________________________________________
gather_data: get branch name from the job JSON                                                                          
                                                                                                                        
Improves code efficiently with removing unnecessary run JSON file                                                       
opening.