### PR TITLE
ci: use dawidd6/action-download-artifact@v2.25.0 

### DIFF
--- a/.github/workflows/buckets-delete.yml
+++ b/.github/workflows/buckets-delete.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Get bucket name (strip username)
         run: echo 'BUCKET_NAME=${{ env.DEPLOYMENT_NAME }}-${{ matrix.label }}' >> $GITHUB_ENV
 
-      - uses: dawidd6/action-download-artifact@v2
+      # This action doesn't work for us since version 2.26.0
+      - uses: dawidd6/action-download-artifact@v2.25.0
         with:
           workflow: buckets-create.yml
           branch: ${{ github.head_ref }}


### PR DESCRIPTION
With the version dawidd6/action-download-artifact@v2.26.0, we had the
fail:
```
Error: no matching workflow run found with any artifacts?
```
This patch fixes this problem with using action version 2.25.0.