### PR TITLE
fix reverse readline

### DIFF
--- a/multivac/gather_data.py
+++ b/multivac/gather_data.py
@@ -67,27 +67,29 @@ def reverse_readline(filename, buf_size=8192):
             try:
                 buffer = fh.read(min(remaining_size, buf_size))
             except UnicodeDecodeError:
+                print(f'ERROR when reading {filename}: UnicodeDecodeError')
                 yield ''
-            remaining_size -= buf_size
-            lines = buffer.split('\n')
-            # The first line of the buffer is probably not a complete line so
-            # we'll save it and append it to the last line of the next buffer
-            # we read
-            if segment is not None:
-                # If the previous chunk starts right from the beginning of line
-                # do not concat the segment to the last line of new chunk.
-                # Instead, yield the segment first
-                if buffer[-1] != '\n':
-                    lines[-1] += segment
-                else:
+            else:
+                remaining_size -= buf_size
+                lines = buffer.split('\n')
+                # The first line of the buffer is probably not a complete line so
+                # we'll save it and append it to the last line of the next buffer
+                # we read
+                if segment is not None:
+                    # If the previous chunk starts right from the beginning of line
+                    # do not concat the segment to the last line of new chunk.
+                    # Instead, yield the segment first
+                    if buffer[-1] != '\n':
+                        lines[-1] += segment
+                    else:
+                        yield segment
+                segment = lines[0]
+                for index in range(len(lines) - 1, 0, -1):
+                    if lines[index]:
+                        yield lines[index]
+                # Don't yield None if the file was empty
+                if segment is not None:
                     yield segment
-            segment = lines[0]
-            for index in range(len(lines) - 1, 0, -1):
-                if lines[index]:
-                    yield lines[index]
-        # Don't yield None if the file was empty
-        if segment is not None:
-            yield segment
 
 
 def detect_error(logs: str, failure_specs: list) -> (str, str):


### PR DESCRIPTION
Logs from FreeBSD runners can provde en error:

```
Traceback (most recent call last):
  File "./multivac/gather_data.py", line 612, in <module>
    result.gather_data()
  File "./multivac/gather_data.py", line 317, in gather_data
    job_failure_type, failure_line = detect_error(logs,
  File "./multivac/gather_data.py", line 95, in detect_error
    for number, line in enumerate(reverse_readline(logs)):
  File "./multivac/gather_data.py", line 73, in reverse_readline
    lines = buffer.split('\n')
UnboundLocalError: local variable 'buffer' referenced before assignment
```

We get this error when we have UnicodeDecodeError on reading line.
This patch fixes this error handling.