### PR TITLE
gather_data: replace symbols we can't decode utf8

### DIFF
--- a/multivac/gather_data.py
+++ b/multivac/gather_data.py
@@ -56,7 +56,7 @@ def decolor(data):
 # start to parse the file from the end to speed up the process
 def reverse_readline(filename, buf_size=8192):
     """An iterator that returns the lines of a file in reverse order"""
-    with open(filename, encoding='utf8') as fh:
+    with open(filename, encoding='utf8', errors='replace') as fh:
         segment = None
         offset = 0
         fh.seek(0, os.SEEK_END)


### PR DESCRIPTION
In the reverse_readline(), if we can't decode symbol we get UnicodeDecodeError and skip an entire line. Option "errors='replace'" allows to replace unknown symbols with \ufffd unicode symbol (special unicode symbol to replace unknown charachters).

Follows up #122