### PR TITLE
ci: stop making CSV 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,6 @@ jobs:
         run: ./multivac/fetch.py --branch 2.10 ${{ matrix.repo }}
         working-directory: /mnt/storage/multivac
 
-      - name: make csv
-        run: ./multivac/last_seen.py --branch master --branch 2.10 --branch 2.11
-        working-directory: /mnt/storage/multivac
-
       - name: Write data to InfluxDB
         env:
           INFLUX_JOB_BUCKET: ${{ secrets.INFLUX_JOB_BUCKET }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,10 +26,6 @@ jobs:
         run: ./multivac/fetch.py --branch 2.11 ${{ matrix.repo }}
         working-directory: /mnt/storage/multivac
 
-      - name: fetch.py for 2.10
-        run: ./multivac/fetch.py --branch 2.10 ${{ matrix.repo }}
-        working-directory: /mnt/storage/multivac
-
       - name: Write data to InfluxDB
         env:
           INFLUX_JOB_BUCKET: ${{ secrets.INFLUX_JOB_BUCKET }}


### PR DESCRIPTION
Multivac dashboard collects all the info we have in the CSV collected
with `last_seen`, so we don't need to duplicate this feature.