### PR TITLE
ci: rename LTS branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: /mnt/storage/multivac
 
       - name: fetch.py for 2.11
-        run: ./multivac/fetch.py --branch 2.11 ${{ matrix.repo }}
+        run: ./multivac/fetch.py --branch release/2.11 ${{ matrix.repo }}
         working-directory: /mnt/storage/multivac
 
       - name: Write data to InfluxDB


### PR DESCRIPTION
On the 2nd of July LTS branch in tarantool/tarantool was renamed to release/2.11, so we need to rename this in the CI.