### PR TITLE
fix: don't throw error on 404

### DIFF
--- a/multivac/fetch.py
+++ b/multivac/fetch.py
@@ -96,7 +96,10 @@ def http_get(url, params=None):
         else:
             fmt = '[Don\'t log response with unknown Content-Type: {}]'
             response_text = fmt.format(content_type)
-        r.raise_for_status()
+        if r.status_code != 404:
+            r.raise_for_status()
+        else:
+            info(f"======================ERROR 404 FOR URL======================\n{url}")
     else:
         response_text = '[EMPTY LOG!]'
 


### PR DESCRIPTION
If there are 404 on trying to download job content, we want to silently skip this job and continue to collect data about other jobs. Since this patch, `raise_for_error()` doesn't call for
`requests.exceptions.HTTPError: 404 Client Error`.

Job succeed for branches master, release/2.11 on my branch: https://github.com/tarantool/multivac/actions/runs/15326210906/job/43121270275
Job failed or branches master, release/2.11 on master before this patch: https://github.com/tarantool/multivac/actions/runs/15324343717